### PR TITLE
Fixes syntax error on recipes/default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,8 +21,7 @@
 include_recipe "java::#{node['java']['install_flavor']}"
 
 # Purge the deprecated Sun Java packages if remove_deprecated_packages is true
-%w[sun-java6-jdk sun-java6-bin sun-java6-jre].each
-do |pkg|
+%w[sun-java6-jdk sun-java6-bin sun-java6-jre].each do |pkg|
   package pkg do
     action :purge
     only_if { node['java']['remove_deprecated_packages'] }


### PR DESCRIPTION
The file used to throw a syntax error when uploading the cookbook with ruby 1.9.2p290.
