### PR TITLE
Allow hosting of the ark on https

### DIFF
--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -19,7 +19,7 @@
 
 actions :install, :remove
 
-attribute :url, :regex => /^http:\/\/.*(tar.gz|tgz|bin|zip)$/, :default => nil
+attribute :url, :regex => /^https?:\/\/.*(tar.gz|tgz|bin|zip)$/, :default => nil
 attribute :mirrorlist, :kind_of => Array, :default => nil
 attribute :checksum, :regex => /^[a-zA-Z0-9]{64}$/, :default => nil
 attribute :app_home, :kind_of => String, :default => nil


### PR DESCRIPTION
I changed the ark resource's url parameter regex to accept http secure as well.
Very minor, but useful.
