### PR TITLE
Fix openjdk install error on Amazon Linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default['java']['jdk_version'] = '6'
 default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? "x86_64" : "i586"
 
 case platform
-when "centos","redhat","fedora","scientific", "amazon"
+when "centos","redhat","fedora","scientific","amazon"
   default['java']['java_home'] = "/usr/lib/jvm/java"
 when "freebsd"
   default['java']['java_home'] = "/usr/local/openjdk#{java['jdk_version']}"


### PR DESCRIPTION
Since Amazon Linux has versions of the form 'YYYY.MM', the check arch check added for Ubuntu > 12.04 currently catches for Amazon Linux too. This is incorrect, so I've firmed up to the check to make sure the platform is Ubuntu.
