### PR TITLE
amend provider to deal with Oracle shipping tgz as opposed to tar.gz

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -31,7 +31,7 @@ def parse_app_dir_name url
     package_name = file_name.scan(/[a-z]+/)[0]
     app_dir_name = "#{package_name}1.#{major_num}.0_#{update_num}"
   else
-    app_dir_name = file_name.split(/(.tar.gz|.zip)/)[0]
+    app_dir_name = file_name.split(/(.tgz|.tar.gz|.zip)/)[0]
     app_dir_name = app_dir_name.split("-bin")[0]
   end
   [app_dir_name, file_name]
@@ -87,7 +87,7 @@ action :install do
       unless cmd.exitstatus == 0
         Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
       end
-    when /^.*\.tar.gz/
+    when /^.*\.(tgz|tar.gz)/
       cmd = Chef::ShellOut.new(
                          %Q[ tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{tmpdir}" ]
                                ).run_command

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -19,7 +19,7 @@
 
 actions :install, :remove
 
-attribute :url, :regex => /^http:\/\/.*(tar.gz|bin|zip)$/, :default => nil
+attribute :url, :regex => /^http:\/\/.*(tgz|tar.gz|bin|zip)$/, :default => nil
 attribute :mirrorlist, :kind_of => Array, :default => nil
 attribute :checksum, :regex => /^[a-zA-Z0-9]{64}$/, :default => nil
 attribute :app_home, :kind_of => String, :default => nil


### PR DESCRIPTION
Oracle seems to ship jdks as .tgz now, which fails the resource regex compare and doesnt work with the provider.  This pull req adjusts both to accommodate.
