### PR TITLE
COOK-1655 add check for ubuntu so amz linux 2012.03 doesnt match accidentally

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -43,7 +43,7 @@ if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon")
   ruby_block "update-java-alternatives" do
     block do
       arch = node['kernel']['machine'] =~ /x86_64/ ? "x86_64" : "i386"
-      arch = 'amd64' if arch == 'x86_64' && node["platform_version"].to_f >= 12.04
+      arch = 'amd64' if arch == 'x86_64' && platform?("ubuntu") && node["platform_version"].to_f >= 12.04
       if platform?("ubuntu", "debian") and jdk_version == 6
         java_name = if node["platform_version"].to_f >= 11.10
           "java-1.6.0-openjdk"


### PR DESCRIPTION
Had a bug with amazon linux. Recipe was setting arch to amd64 since 2012.03 >= 12.04.

Added check for ubuntu to if statement.
