### PR TITLE
Fixed typo in Oracle i586 Java 6 URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,7 @@ default['java']['jdk']['6']['x86_64']['url'] = 'http://download.oracle.com/otn-p
 default['java']['jdk']['6']['x86_64']['checksum'] = '51d594cec29948bdf58918ba802a872826bc7caae3f0aada42b65eacdc14a7f4'
 
 # i586
-default['java']['jdk']['6']['i586']['url'] = 'hhttp://download.oracle.com/otn-pub/java/jdk/6u37-b06/jdk-6u37-linux-i586.bin'
+default['java']['jdk']['6']['i586']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/6u37-b06/jdk-6u37-linux-i586.bin'
 default['java']['jdk']['6']['i586']['checksum'] = '44cc51ed452a08a3e0b4e397922832607161642e5a6e206f256af86f8fbaae90'
 
 # jdk7 attributes


### PR DESCRIPTION
Downloading Java 6 i585 from Oracle failed because of a typo in the URL:

```
hhttp://download.oracle.com/otn-pub/java/jdk/6u37-b06/jdk-6u37-linux-i586.bin
```

(Two "h"s at the beginning.) This pull request fixes that typo.
