### PR TITLE
[COOK-3763] Prevent "openjdk" recipe failing on CentOS 6.

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -67,11 +67,10 @@ if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon")
         Chef::Log.debug("glob is #{java_home_parent}/java*#{jdk_version}*openjdk*#{arch}")
         jdk_home = Dir.glob("#{java_home_parent}/java*#{jdk_version}*openjdk*#{arch}").first
         Chef::Log.debug("jdk_home is #{jdk_home}")
-        # delete the symlink if it already exists
-        if ::File.exists? java_home
-          FileUtils.rm_f java_home
+        if jdk_home
+          FileUtils.rm_f java_home if ::File.exists? java_home
+          FileUtils.ln_sf jdk_home, java_home
         end
-        FileUtils.ln_sf jdk_home, java_home
 
         cmd = Chef::ShellOut.new(
           %Q[ update-alternatives --install /usr/bin/java java #{java_home}/bin/java 1;


### PR DESCRIPTION
The error is caused by an incorrect glob in the "update-java-alternatives" block.

Since the code in the block is too complex to attempt to fix the root cause,
the provided patch only ensures the code does not fail unnecessarily.
