### PR TITLE
Fixed deprecation warnings for use of Chef::ShellOut

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -65,7 +65,7 @@ def download_direct_from_oracle(tarball_name, new_resource)
     description = "download oracle tarball straight from the server"
     converge_by(description) do
        Chef::Log.debug "downloading oracle tarball straight from the source"
-       cmd = Chef::ShellOut.new(
+       cmd = Mixlib::ShellOut.new(
                                   %Q[ curl -L --cookie "#{cookie}" #{new_resource.url} -o #{download_path} ]
                                )
        cmd.run_command
@@ -128,7 +128,7 @@ action :install do
        tmpdir = Dir.mktmpdir
        case tarball_name
        when /^.*\.bin/
-         cmd = Chef::ShellOut.new(
+         cmd = Mixlib::ShellOut.new(
                                   %Q[ cd "#{tmpdir}";
                                       cp "#{Chef::Config[:file_cache_path]}/#{tarball_name}" . ;
                                       bash ./#{tarball_name} -noregister
@@ -137,14 +137,14 @@ action :install do
            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
          end
        when /^.*\.zip/
-         cmd = Chef::ShellOut.new(
+         cmd = Mixlib::ShellOut.new(
                             %Q[ unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{tmpdir}" ]
                                   ).run_command
          unless cmd.exitstatus == 0
            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
          end
        when /^.*\.(tar.gz|tgz)/
-         cmd = Chef::ShellOut.new(
+         cmd = Mixlib::ShellOut.new(
                             %Q[ tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{tmpdir}" ]
                                   ).run_command
          unless cmd.exitstatus == 0
@@ -152,7 +152,7 @@ action :install do
          end
        end
 
-       cmd = Chef::ShellOut.new(
+       cmd = Mixlib::ShellOut.new(
                           %Q[ mv "#{tmpdir}/#{app_dir_name}" "#{app_dir}" ]
                                 ).run_command
        unless cmd.exitstatus == 0
@@ -205,12 +205,12 @@ action :install do
       priority = new_resource.alternatives_priority
 
       # install the alternative if needed
-      alternative_exists = Chef::ShellOut.new("update-alternatives --display #{cmd} | grep #{alt_path}").run_command.exitstatus == 0
+      alternative_exists = Mixlib::ShellOut.new("update-alternatives --display #{cmd} | grep #{alt_path}").run_command.exitstatus == 0
       unless alternative_exists
         description = "Add alternative for #{cmd}"
         converge_by(description) do
           Chef::Log.debug "Adding alternative for #{cmd}"
-          install_cmd = Chef::ShellOut.new("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}").run_command
+          install_cmd = Mixlib::ShellOut.new("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}").run_command
           unless install_cmd.exitstatus == 0
             Chef::Application.fatal!(%Q[ set alternative failed ])
           end
@@ -220,12 +220,12 @@ action :install do
 
       # set the alternative if default
       if new_resource.default
-        alternative_is_set = Chef::ShellOut.new("update-alternatives --display #{cmd} | grep \"link currently points to #{alt_path}\"").run_command.exitstatus == 0
+        alternative_is_set = Mixlib::ShellOut.new("update-alternatives --display #{cmd} | grep \"link currently points to #{alt_path}\"").run_command.exitstatus == 0
         unless alternative_is_set
           description = "Set alternative for #{cmd}"
           converge_by(description) do
             Chef::Log.debug "Setting alternative for #{cmd}"
-            set_cmd = Chef::ShellOut.new("update-alternatives --set #{cmd} #{alt_path}").run_command
+            set_cmd = Mixlib::ShellOut.new("update-alternatives --set #{cmd} #{alt_path}").run_command
             unless set_cmd.exitstatus == 0
               Chef::Application.fatal!(%Q[ set alternative failed ])
             end

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -63,7 +63,7 @@ if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon")
           "java-6-openjdk"
         end
         java_name += "-i386" if arch == "i386" && node['platform_version'].to_f >= 12.04
-        Chef::ShellOut.new("update-java-alternatives","-s", java_name, :returns => [0,2]).run_command
+        Mixlib::ShellOut.new("update-java-alternatives","-s", java_name, :returns => [0,2]).run_command
       else
         # have to do this on ubuntu for version 7 because Ubuntu does
         # not currently set jdk 7 as the default jvm on installation
@@ -76,7 +76,7 @@ if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon")
           FileUtils.ln_sf jdk_home, java_home
         end
 
-        cmd = Chef::ShellOut.new(
+        cmd = Mixlib::ShellOut.new(
           %Q[ update-alternatives --install /usr/bin/java java #{java_home}/bin/java 1;
              update-alternatives --set java #{java_home}/bin/java  ]
           ).run_command


### PR DESCRIPTION
When using Chef::ShellOut with chef-client 11.x, the following warnings come up during a run:

```
[2013-02-14T20:28:19+00:00] WARN: Chef::ShellOut is deprecated, please use Mixlib::ShellOut
[2013-02-14T20:28:19+00:00] WARN: Called from:
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/java/providers/ark.rb:68:in `new'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/java/providers/ark.rb:68:in `block in download_direct_from_oracle'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/mixin/why_run.rb:52:in `call'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/mixin/why_run.rb:52:in `add_action'
```

Changed all calls to Chef::ShellOut to Mixlib::ShellOut
