### PR TITLE
Added oracle to list of supported platforms

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default['java']['jdk_version'] = '6'
 default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? "x86_64" : "i586"
 
 case platform
-when "centos","redhat","fedora","scientific","amazon"
+when "centos","redhat","fedora","scientific","amazon","oracle"
   default['java']['java_home'] = "/usr/lib/jvm/java"
 when "freebsd"
   default['java']['java_home'] = "/usr/local/openjdk#{java['jdk_version']}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe "java::oracle", "Installs the Oracle flavor of Java"
 recipe "java::oracle_i386", "Installs the 32-bit jvm without setting it as the default"
 
 
-%w{ debian ubuntu centos redhat scientific fedora amazon arch freebsd windows }.each do |os|
+%w{ debian ubuntu centos redhat scientific fedora amazon arch oracle freebsd windows }.each do |os|
   supports os
 end
 

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -23,7 +23,7 @@ java_home_parent = ::File.dirname java_home
 jdk_home = ""
 
 pkgs = value_for_platform(
-  ["centos","redhat","fedora","scientific","amazon"] => {
+  ["centos","redhat","fedora","scientific","amazon","oracle"] => {
     "default" => ["java-1.#{jdk_version}.0-openjdk","java-1.#{jdk_version}.0-openjdk-devel"]
   },
   ["debian","ubuntu"] => {
@@ -51,7 +51,7 @@ file "/etc/profile.d/jdk.sh" do
 end
 
 
-if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon")
+if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon","oracle")
   ruby_block "update-java-alternatives" do
     block do
       arch = node['kernel']['machine'] =~ /x86_64/ ? "x86_64" : "i386"
@@ -92,6 +92,6 @@ end
 pkgs.each do |pkg|
   package pkg do
     action :install
-    notifies :create, "ruby_block[update-java-alternatives]", :immediately if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon")
+    notifies :create, "ruby_block[update-java-alternatives]", :immediately if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon","oracle")
   end
 end


### PR DESCRIPTION
Tried to install the openjdk version of java on an Oracle Enterprise Linux system today and realized that oracle wasn't listed in the platforms.

Added oracle to the list of support platforms.
