### PR TITLE
replacing default-jre-headless with jdk_version

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -27,7 +27,7 @@ pkgs = value_for_platform(
     "default" => ["java-1.#{jdk_version}.0-openjdk","java-1.#{jdk_version}.0-openjdk-devel"]
   },
   ["debian","ubuntu"] => {
-    "default" => ["openjdk-#{jdk_version}-jdk","default-jre-headless"]
+    "default" => ["openjdk-#{jdk_version}-jdk", "openjdk-#{jdk_version}-jre-headless"]
   },
   ["arch","freebsd"] => {
     "default" => ["openjdk#{jdk_version}"]


### PR DESCRIPTION
on ubuntu default-jre-headless will always install the openjdk-6-jre-headless.
