### PR TITLE
[COOK-2563] Installation fails when we have a dirty '/var/lib/alternatives/#{cmd}'

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ After putting the binaries in place, the `java::oracle` recipe updates
 `update-alternatives` script. This is all handled in the `java_ark`
 LWRP.
 
+For both **debian** and **centos/rhel**, this recipe pulls the binary
+distribution from the Oracle website, and installs it in the default
+*JAVA_HOME* for each distribution. For debian/ubuntu, this is
+*/usr/lib/jvm/default-java*. For Centos/RHEL, this is */usr/lib/jvm/java*.
+
+After putting the binaries in place, the oracle recipe updates
+**/usr/bin/java** to point to the installed JDK using the
+`update-alternatives` script. Prior setting the _alternative_ of each command
+the recipe **removes** any reference of the given command in the _alternatives_ 
+lib folder (_/var/lib/alternatives/_).
+
 ## oracle_i386
 
 This recipe installs the 32-bit Java virtual machine without setting
@@ -242,6 +253,26 @@ To install IBM flavored Java, set the required attributes:
     run_list(
       "recipe[java]"
     )
+
+If on the other hand you have your own HTTP(S) server that provides the tar file your configuration will look like:
+
+```ruby
+    :java => {
+        :install_flavor => "oracle",
+        # Setup a specific JAVA_HOME that is available for CDH4 /usr/libexec/bigtop-detect-javahome
+        :java_home => "/usr/lib/jvm/default-java",
+        :jdk_version => "7",
+        :arch => "x64",
+        :jdk => {
+            7 => {
+                :x64 => {
+                    :url => "http://vagrant-archive.33.33.33.1.xip.io/jdk/jdk-7u17-linux-x64.tar.gz",
+                    :checksum => "8611ce31e0b7ecb99d34703ad89b29a545a3fb30356553be3674366cbe722782"
+                }
+            }
+        }
+    }
+```
 
 
 Development

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -210,6 +210,8 @@ action :install do
       unless alternative_exists
         description = "Add alternative for #{cmd}"
         converge_by(description) do
+          Chef::Log.debug "Removing alternative /var/lib/alternatives/#{cmd} since alternatives --install fails if such file exists."
+          rm_cmd = MixLib::ShellOut.new("rm /var/lib/alternatives/#{cmd}").run_command
           Chef::Log.debug "Adding alternative for #{cmd}"
           install_cmd = shell_out("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}")
           unless install_cmd.exitstatus == 0

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -44,6 +44,12 @@ end
 
 include_recipe "java::set_java_home"
 
+unless bin_cmds
+
+    Chef::Log.warn("There were no Bin Commands (see the 'bin_cmds' in the attributes) detected. No alternatives will get linked, i.e. the `/urs/bin/java` will not be there on not reflect the intended version. You are either not providing them explicitly or overriding them accidentaly.")
+
+end
+
 java_ark "jdk" do
   url tarball_url
   checksum tarball_checksum


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2563

The install will fail if `update-alternatives --display` shows no reference of a given command but there is one in `/var/lib/alternatives`. Apparently this might be caused by a previous install of a package.
To fix the problem we need to remove any reference of the command in `/var/lib/alternatives`.
