### PR TITLE
Fixed deprecation warnings for use of Chef::ShellOut

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -17,6 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
 def whyrun_supported?
   true
 end
@@ -65,7 +68,7 @@ def download_direct_from_oracle(tarball_name, new_resource)
     description = "download oracle tarball straight from the server"
     converge_by(description) do
        Chef::Log.debug "downloading oracle tarball straight from the source"
-       cmd = Chef::ShellOut.new(
+       cmd = shell_out(
                                   %Q[ curl -L --cookie "#{cookie}" #{new_resource.url} -o #{download_path} ]
                                )
        cmd.run_command
@@ -128,7 +131,7 @@ action :install do
        tmpdir = Dir.mktmpdir
        case tarball_name
        when /^.*\.bin/
-         cmd = Chef::ShellOut.new(
+         cmd = shell_out(
                                   %Q[ cd "#{tmpdir}";
                                       cp "#{Chef::Config[:file_cache_path]}/#{tarball_name}" . ;
                                       bash ./#{tarball_name} -noregister
@@ -137,14 +140,14 @@ action :install do
            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
          end
        when /^.*\.zip/
-         cmd = Chef::ShellOut.new(
+         cmd = shell_out(
                             %Q[ unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{tmpdir}" ]
                                   ).run_command
          unless cmd.exitstatus == 0
            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
          end
        when /^.*\.(tar.gz|tgz)/
-         cmd = Chef::ShellOut.new(
+         cmd = shell_out(
                             %Q[ tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{tmpdir}" ]
                                   ).run_command
          unless cmd.exitstatus == 0
@@ -152,7 +155,7 @@ action :install do
          end
        end
 
-       cmd = Chef::ShellOut.new(
+       cmd = shell_out(
                           %Q[ mv "#{tmpdir}/#{app_dir_name}" "#{app_dir}" ]
                                 ).run_command
        unless cmd.exitstatus == 0
@@ -205,12 +208,12 @@ action :install do
       priority = new_resource.alternatives_priority
 
       # install the alternative if needed
-      alternative_exists = Chef::ShellOut.new("update-alternatives --display #{cmd} | grep #{alt_path}").run_command.exitstatus == 0
+      alternative_exists = shell_out("update-alternatives --display #{cmd} | grep #{alt_path}").run_command.exitstatus == 0
       unless alternative_exists
         description = "Add alternative for #{cmd}"
         converge_by(description) do
           Chef::Log.debug "Adding alternative for #{cmd}"
-          install_cmd = Chef::ShellOut.new("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}").run_command
+          install_cmd = shell_out("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}").run_command
           unless install_cmd.exitstatus == 0
             Chef::Application.fatal!(%Q[ set alternative failed ])
           end
@@ -220,12 +223,12 @@ action :install do
 
       # set the alternative if default
       if new_resource.default
-        alternative_is_set = Chef::ShellOut.new("update-alternatives --display #{cmd} | grep \"link currently points to #{alt_path}\"").run_command.exitstatus == 0
+        alternative_is_set = shell_out("update-alternatives --display #{cmd} | grep \"link currently points to #{alt_path}\"").run_command.exitstatus == 0
         unless alternative_is_set
           description = "Set alternative for #{cmd}"
           converge_by(description) do
             Chef::Log.debug "Setting alternative for #{cmd}"
-            set_cmd = Chef::ShellOut.new("update-alternatives --set #{cmd} #{alt_path}").run_command
+            set_cmd = shell_out("update-alternatives --set #{cmd} #{alt_path}").run_command
             unless set_cmd.exitstatus == 0
               Chef::Application.fatal!(%Q[ set alternative failed ])
             end

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -17,6 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
 jdk_version = node['java']['jdk_version'].to_i
 java_home = node['java']['java_home']
 java_home_parent = ::File.dirname java_home
@@ -63,7 +66,7 @@ if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon",
           "java-6-openjdk"
         end
         java_name += "-i386" if arch == "i386" && node['platform_version'].to_f >= 12.04
-        Chef::ShellOut.new("update-java-alternatives","-s", java_name, :returns => [0,2]).run_command
+        shell_out("update-java-alternatives","-s", java_name, :returns => [0,2]).run_command
       else
         # have to do this on ubuntu for version 7 because Ubuntu does
         # not currently set jdk 7 as the default jvm on installation
@@ -76,7 +79,7 @@ if platform?("ubuntu","debian","redhat","centos","fedora","scientific","amazon",
           FileUtils.ln_sf jdk_home, java_home
         end
 
-        cmd = Chef::ShellOut.new(
+        cmd = shell_out(
           %Q[ update-alternatives --install /usr/bin/java java #{java_home}/bin/java 1;
              update-alternatives --set java #{java_home}/bin/java  ]
           ).run_command


### PR DESCRIPTION
Fixes COOK-2488 and COOK-2415.

See also pull request #37 and #46.

Cheers!
