### PR TITLE
COOK-2728 Java cookbook does not properly set JAVA_HOME for ubuntu 12.04...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,12 @@ when "windows"
   default['java']['install_flavor'] = "windows"
   default['java']['windows']['url'] = nil
   default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
+when "ubuntu"
+  if platform_version.to_f >= 12.04 && java['install_flavor'] == "openjdk" 
+    default['java']['java_home'] = "/usr/lib/jvm/java-1.#{java['jdk_version']}.0-openjdk-#{kernel['machine'] =~ /x86_64/ ? "amd64" : "i386"}"
+  else
+    default['java']['java_home'] = "/usr/lib/jvm/default-java"
+  end
 else
   default['java']['java_home'] = "/usr/lib/jvm/default-java"
 end

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -27,6 +27,7 @@ pkgs = value_for_platform(
     "default" => ["java-1.#{jdk_version}.0-openjdk","java-1.#{jdk_version}.0-openjdk-devel"]
   },
   ["debian","ubuntu"] => {
+    "12.04" => ["openjdk-#{jdk_version}-jdk","openjdk-#{jdk_version}-jre-headless"], 
     "default" => ["openjdk-#{jdk_version}-jdk","default-jre-headless"]
   },
   ["arch","freebsd"] => {


### PR DESCRIPTION
This commit fixes the incorrectly set JAVA_HOME for ubuntu12.04 when using openjdk 6 or 7.

http://tickets.opscode.com/browse/COOK-2728
