### PR TITLE
COOK-2847 Java cookbook does not have opensuse support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe "java::oracle", "Installs the Oracle flavor of Java"
 recipe "java::oracle_i386", "Installs the 32-bit jvm without setting it as the default"
 
 
-%w{ debian ubuntu centos redhat scientific fedora amazon arch oracle freebsd windows }.each do |os|
+%w{ debian ubuntu centos redhat scientific fedora amazon arch oracle freebsd windows suse }.each do |os|
   supports os
 end
 


### PR DESCRIPTION
Simply added the 'suse' label to the list of OS's in metadata.rb.
