### PR TITLE
Regex failing for checksums fix.

### DIFF
--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -21,7 +21,7 @@ actions :install, :remove
 
 attribute :url, :regex => /^https?:\/\/.*(tar.gz|tgz|bin|zip)$/, :default => nil
 attribute :mirrorlist, :kind_of => Array, :default => nil
-attribute :checksum, :regex => /^[a-zA-Z0-9]{40}$/, :default => nil
+attribute :checksum, :regex => /^[a-zA-Z0-9]{40,64}$/, :default => nil
 attribute :app_home, :kind_of => String, :default => nil
 attribute :app_home_mode, :kind_of => Integer, :default => 0755
 attribute :bin_cmds, :kind_of => Array, :default => nil


### PR DESCRIPTION
Setting a range for the checksum so it works with sha256 checksum length. This fixes a bug where my setting the checksum to the default checksum on one node to ensure it got the default version resulted in a chef run fail reporting that the checksum didn't match the regex.

If this was not the intended use please let me know a better way...

Ticket: https://tickets.opscode.com/browse/COOK-3569
