### PR TITLE
Added support for platform xenserver (for installations of java in DOM0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Platform
 --------
 
 * Debian, Ubuntu
-* CentOS, Red Hat, Fedora, Scientific, Amazon
+* CentOS, Red Hat, Fedora, Scientific, Amazon, XenServer
 * ArchLinux
 * FreeBSD
 * Windows

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default['java']['jdk_version'] = '6'
 default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? "x86_64" : "i586"
 
 case platform
-when "centos","redhat","fedora","scientific","amazon","oracle"
+when "centos","redhat","fedora","scientific","amazon","oracle","xenserver"
   default['java']['java_home'] = "/usr/lib/jvm/java"
 when "freebsd"
   default['java']['java_home'] = "/usr/local/openjdk#{java['jdk_version']}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe "java::oracle", "Installs the Oracle flavor of Java"
 recipe "java::oracle_i386", "Installs the 32-bit jvm without setting it as the default"
 
 
-%w{ debian ubuntu centos redhat scientific fedora amazon arch oracle freebsd windows }.each do |os|
+%w{ debian ubuntu centos redhat scientific fedora amazon arch oracle freebsd windows xenserver }.each do |os|
   supports os
 end
 

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -23,7 +23,7 @@ java_home_parent = ::File.dirname java_home
 jdk_home = ""
 
 pkgs = value_for_platform(
-  ["centos","redhat","fedora","scientific","amazon","oracle"] => {
+  ["centos","redhat","fedora","scientific","amazon","oracle","xenserver"] => {
     "default" => ["java-1.#{jdk_version}.0-openjdk","java-1.#{jdk_version}.0-openjdk-devel"]
   },
   ["debian","ubuntu"] => {


### PR DESCRIPTION
When using the java cookbook to install java into DOM0 on a XenServer it does not check for the platform type 'xenserver'. This causes the cookbook to use the wrong settings (the defaults for an unknown platform) which fail and break the installation.
