### PR TITLE
COOK-2931 Updated the cookbook so it actively supports XenServer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Chef 0.10.10+ and Ohai 6.10+ for `platform_family` use.
 ## Platform
 
 * Debian, Ubuntu
-* CentOS, Red Hat, Fedora, Scientific, Amazon
+* CentOS, Red Hat, Fedora, Scientific, Amazon, XenServer
 * ArchLinux
 * FreeBSD
 * Windows

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe "java::oracle", "Installs the Oracle flavor of Java"
 recipe "java::oracle_i386", "Installs the 32-bit jvm without setting it as the default"
 
 
-%w{ debian ubuntu centos redhat scientific fedora amazon arch oracle freebsd windows suse }.each do |os|
+%w{ debian ubuntu centos redhat scientific fedora amazon arch oracle freebsd windows suse xenserver}.each do |os|
   supports os
 end
 


### PR DESCRIPTION
This commit depends on OHAI-472 which adjusts OHAI so it assigns XenServer to the correct platform_family.
