### PR TITLE
COOK-3295 - Fix openjdk_path function in helper library

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,6 +46,8 @@ module Opscode
         'jre-1.%s.0-openjdk%s' % [@jdk_version, arch_dir]
       when 'smartos'
         'jre'
+      else
+        'jre'
       end
     end
 


### PR DESCRIPTION
helpers.rb no longer returns nil if the platform_family doesn't match 'debian', 'rhea', 'fedora', or 'smartos'.

This is useful when writing chefspec tests for cookbooks that include_recipe java::default, as there may be no declared platform in a spec test.
