### PR TITLE
Logging error if set alternatives fails

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -215,7 +215,7 @@ action :install do
           Chef::Log.debug "Adding alternative for #{cmd}"
           install_cmd = shell_out("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}").run_command
           unless install_cmd.exitstatus == 0
-            Chef::Application.fatal!(%Q[ set alternative failed ])
+            Chef::Application.fatal!(%Q[ Set alternative failed: #{install_cmd.error!} ])
           end
         end
         new_resource.updated_by_last_action(true)
@@ -230,7 +230,7 @@ action :install do
             Chef::Log.debug "Setting alternative for #{cmd}"
             set_cmd = shell_out("update-alternatives --set #{cmd} #{alt_path}").run_command
             unless set_cmd.exitstatus == 0
-              Chef::Application.fatal!(%Q[ set alternative failed ])
+              Chef::Application.fatal!(%Q[ Set alternative failed: #{set_cmd.error!} ])
             end
           end
           new_resource.updated_by_last_action(true)


### PR DESCRIPTION
`update-alternatives --set` always fails when using in vagrant + precise32. Will investigate why, as for now at least logging should be added if the command fails. That's what I'm adding here..
