### PR TITLE
Updated windows installer to honor 'java_home'

### DIFF
--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -24,5 +24,9 @@ windows_package node['java']['windows']['package_name'] do
   source node['java']['windows']['url']
   action :install
   installer_type :custom
-  options "/s"
+  
+  java_home = node['java']['java_home']
+  opts = "/s"
+  opts += " /INSTALLDIR=#{java_home}" unless java_home == nil
+  options opts
 end


### PR DESCRIPTION
Updated the windows recipe to install Java to the path specified by 'java_home', if any.
