### PR TITLE
COOK-3488: set alternatives for ibm jdk

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,14 @@ if node['java']['install_flavor'] == 'ibm'
   default['java']['ibm']['checksum'] = nil
   default['java']['ibm']['accept_ibm_download_terms'] = false
   default['java']['java_home'] = "/opt/ibm/java"
+
+  default['java']['ibm']['6']['bin_cmds'] = [ "appletviewer", "apt", "ControlPanel", "extcheck", "HtmlConverter", "idlj", "jar", "jarsigner",
+                                              "java", "javac", "javadoc", "javah", "javap", "javaws", "jconsole", "jcontrol", "jdb", "jdmpview",
+                                              "jrunscript", "keytool", "native2ascii", "policytool", "rmic", "rmid", "rmiregistry",
+                                              "schemagen", "serialver", "tnameserv", "wsgen", "wsimport", "xjc" ]
+
+  default['java']['ibm']['7']['bin_cmds'] = node['java']['ibm']['6']['bin_cmds'] + [ "pack200", "unpack200" ]
+
 end
 
 # if you change this to true, you can download directly from Oracle

--- a/providers/alternatives.rb
+++ b/providers/alternatives.rb
@@ -1,0 +1,71 @@
+#
+# Cookbook Name:: java
+# Provider:: alternatives
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
+action :set do
+  if new_resource.bin_cmds
+    new_resource.bin_cmds.each do |cmd|
+
+      bin_path = "/usr/bin/#{cmd}"
+      alt_path = "#{new_resource.java_location}/bin/#{cmd}"
+      priority = new_resource.priority
+
+      # install the alternative if needed
+      alternative_exists = shell_out("update-alternatives --display #{cmd} | grep #{alt_path}").run_command.exitstatus == 0
+      unless alternative_exists
+        description = "Add alternative for #{cmd}"
+        converge_by(description) do
+          Chef::Log.debug "Adding alternative for #{cmd}"
+          install_cmd = shell_out("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}").run_command
+          unless install_cmd.exitstatus == 0
+            Chef::Application.fatal!(%Q[ set alternative failed ])
+          end
+        end
+        new_resource.updated_by_last_action(true)
+      end
+
+      # set the alternative if default
+      if new_resource.default
+        alternative_is_set = shell_out("update-alternatives --display #{cmd} | grep \"link currently points to #{alt_path}\"").run_command.exitstatus == 0
+        unless alternative_is_set
+          description = "Set alternative for #{cmd}"
+          converge_by(description) do
+            Chef::Log.debug "Setting alternative for #{cmd}"
+            set_cmd = shell_out("update-alternatives --set #{cmd} #{alt_path}").run_command
+            unless set_cmd.exitstatus == 0
+              Chef::Application.fatal!(%Q[ set alternative failed ])
+            end
+          end
+          new_resource.updated_by_last_action(true)
+        end
+      end
+    end
+  end
+end
+
+action :unset do
+  new_resource.bin_cmds.each do |cmd|
+    alt_path = "#{new_resource.java_location}/bin/#{cmd}"
+    cmd = shell_out("update-alternatives --remove #{cmd} #{alt_path}").run_command
+    if cmd.exitstatus == 0
+      new_resource.updated_by_last_action(true)
+    end
+  end
+end
+
+  

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -200,44 +200,14 @@ action :install do
   end
 
   #update-alternatives
-  if new_resource.bin_cmds
-    new_resource.bin_cmds.each do |cmd|
-
-      bin_path = "/usr/bin/#{cmd}"
-      alt_path = "#{app_home}/bin/#{cmd}"
-      priority = new_resource.alternatives_priority
-
-      # install the alternative if needed
-      alternative_exists = shell_out("update-alternatives --display #{cmd} | grep #{alt_path}").run_command.exitstatus == 0
-      unless alternative_exists
-        description = "Add alternative for #{cmd}"
-        converge_by(description) do
-          Chef::Log.debug "Adding alternative for #{cmd}"
-          install_cmd = shell_out("update-alternatives --install #{bin_path} #{cmd} #{alt_path} #{priority}").run_command
-          unless install_cmd.exitstatus == 0
-            Chef::Application.fatal!(%Q[ set alternative failed ])
-          end
-        end
-        new_resource.updated_by_last_action(true)
-      end
-
-      # set the alternative if default
-      if new_resource.default
-        alternative_is_set = shell_out("update-alternatives --display #{cmd} | grep \"link currently points to #{alt_path}\"").run_command.exitstatus == 0
-        unless alternative_is_set
-          description = "Set alternative for #{cmd}"
-          converge_by(description) do
-            Chef::Log.debug "Setting alternative for #{cmd}"
-            set_cmd = shell_out("update-alternatives --set #{cmd} #{alt_path}").run_command
-            unless set_cmd.exitstatus == 0
-              Chef::Application.fatal!(%Q[ set alternative failed ])
-            end
-          end
-          new_resource.updated_by_last_action(true)
-        end
-      end
-    end
+  java_alternatives 'set-java-alternatives' do
+    java_location app_home
+    bin_cmds new_resource.bin_cmds
+    priority new_resource.alternatives_priority
+    default new_resource.default
+    action :set
   end
+
 end
 
 action :remove do
@@ -245,15 +215,19 @@ action :remove do
   app_root = new_resource.app_home.split('/')[0..-2].join('/')
   app_dir = app_root + '/' + app_dir_name
 
+  unless new_resource.default
+    Chef::Log.debug("processing alternate jdk")
+    app_dir = app_dir  + "_alt"
+    app_home = new_resource.app_home + "_alt"
+  else
+    app_home = new_resource.app_home
+  end
+
   if ::File.exists?(app_dir)
-    new_resource.bin_cmds.each do |cmd|
-      cmd = execute "update_alternatives" do
-        command "update-alternatives --remove #{cmd} #{app_dir} "
-        returns [0,2]
-        action :nothing
-      end
-      # the execute resource will take care of of the run_action(:run)
-      cmd.run_action(:run)
+    java_alternatives 'unset-java-alternatives' do
+      java_location app_home
+      bin_cmds new_resource.bin_cmds
+      action :unset
     end
     description = "remove #{new_resource.name} at #{app_dir}"
     converge_by(description) do

--- a/recipes/ibm.rb
+++ b/recipes/ibm.rb
@@ -42,6 +42,17 @@ remote_file "#{Chef::Config[:file_cache_path]}/#{jdk_filename}" do
   notifies :run, "execute[install-ibm-java]", :immediately
 end
 
+java_alternatives 'set-java-alternatives' do
+  java_location node['java']['java_home']
+  case node['java']['jdk_version']
+  when "6"
+    bin_cmds node['java']['ibm']['6']['bin_cmds']
+  when "7"
+    bin_cmds node['java']['ibm']['7']['bin_cmds']
+  end
+  action :nothing
+end
+
 execute "install-ibm-java" do
   cwd Chef::Config[:file_cache_path]
   environment({
@@ -49,6 +60,7 @@ execute "install-ibm-java" do
     "LAX_DEBUG" => "1"
   })
   command "./#{jdk_filename} -f ./installer.properties -i silent"
+  notifies :set, 'java_alternatives[set-java-alternatives]', :immediately
   creates "#{node['java']['java_home']}/jre/bin/java"
 end
 

--- a/resources/alternatives.rb
+++ b/resources/alternatives.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: java
+# Provider:: alternatives
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+actions :set, :unset
+
+attribute :java_location, :kind_of => String, :default => nil
+attribute :bin_cmds, :kind_of => Array, :default => nil
+attribute :default, :equal_to => [true, false], :default => true
+attribute :priority, :kind_of => Integer, :default => 1061
+
+# we have to set default for the supports attribute
+# in initializer since it is a 'reserved' attribute name
+def initialize(*args)
+  super
+  @action = :set
+end


### PR DESCRIPTION
Refactored update-alternatives bits out of ark LWRP into a separate LWRP and then reused the new LWRP in ark and ibm recipe.
