### PR TITLE
Created an attribute called ['java']['windows']['options'] to take the p...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ when "windows"
   default['java']['install_flavor'] = "windows"
   default['java']['windows']['url'] = nil
   default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
+  default['java']['windows']['options'] = '/s'
 when "debian"
   default['java']['java_home'] = "/usr/lib/jvm/default-java"
   default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk", "default-jre-headless"]

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -24,5 +24,5 @@ windows_package node['java']['windows']['package_name'] do
   source node['java']['windows']['url']
   action :install
   installer_type :custom
-  options "/s"
+  options node['java']['windows']['options']
 end


### PR DESCRIPTION
Created an attribute called ['java']['windows']['options'] to take the place of the hardcoded /s in the java windows recipe. Now users will be able to pass in their own options and not have to create a override cookbook for one simple change

This was an issue for me as I had to create my own overrides cookbook because I couldn't override the option list. I needed to set the JAVA_HOME to install into and couldn't with the current cookbook
