### PR TITLE
Download java windows binaries from S3 with creds

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -32,3 +32,4 @@ recipe "java::oracle_i386", "Installs the 32-bit jvm without setting it as the d
 end
 
 depends "windows"
+depends "aws"

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -18,10 +18,40 @@
 # limitations under the License.
 #
 
-Chef::Log.warn("No download url set for java installer.") unless node['java']['windows']['url']
+require 'uri'
+
+Chef::Log.fatal("No download url set for java installer.") unless node['java'] && node['java']['windows'] && node['java']['windows']['url']
+
+pkg_checksum = node['java']['windows']['checksum']
+aws_access_key_id = node['java']['windows']['aws_access_key_id']
+aws_secret_access_key = node['java']['windows']['aws_secret_access_key']
+
+uri = ::URI.parse(::URI.unescape(node['java']['windows']['url']))
+cache_file_path = File.join(Chef::Config[:file_cache_path], File.basename(uri.path))
+
+if aws_access_key_id && aws_secret_access_key
+  include_recipe 'aws::default'  # install right_aws gem for aws_s3_file
+
+  aws_s3_file cache_file_path do
+    aws_access_key_id aws_access_key_id
+    aws_secret_access_key aws_secret_access_key
+    checksum pkg_checksum if pkg_checksum
+    bucket node['java']['windows']['bucket']
+    remote_path node['java']['windows']['remote_path']
+    backup false
+    action :create
+  end
+else
+  remote_file cache_file_path do
+    checksum pkg_checksum if pkg_checksum
+    source node['java']['windows']['url']
+    backup false
+    action :create
+  end
+end
 
 windows_package node['java']['windows']['package_name'] do
-  source node['java']['windows']['url']
+  source cache_file_path
   action :install
   installer_type :custom
   options "/s"


### PR DESCRIPTION
Its useful to stuff the java blob into S3 to easily install it across
your own servers, but making this --acl-public on S3 will violate the
oracle license.  This patch is a little messy but accomplishes that
goal.  I didn't like the approach of trying to shove it into the
windows_package provider.  I also don't like pushing the S3 creds into
the node attributes rather than using encrypted databags, but I think
we need to do that for now otherwise you wind up with madness where
you have all kinds of node attrs to select what kind of download you
are doing.

The right way to fix this is through being able to inject information
into cookbooks dynamically:

https://github.com/danielsdeleo/chef-data-bindings

Since that is the right direction to go and any direction we take here
is going to be throwaway work using the wrong primitives, I didn't
try to make this perfect.  We can point to this code, instead, as
a reason why we need something like the chef data bindings.

(And I need to ship this to support the opscode-ci cookbook and stop
that train and allow the perfect to be the enemy of the good...)
