### PR TITLE
[COOK-3541] Java cookbook installs both JDK 6 and JDK 7 when JDK 7 is specified

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,7 +43,7 @@ when "windows"
   default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
 when "debian"
   default['java']['java_home'] = "/usr/lib/jvm/default-java"
-  default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk", "default-jre-headless"]
+  default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk", "openjdk-#{node['java']['jdk_version']}-jre-headless"]
 when "smartos"
   default['java']['java_home'] = "/opt/local/java/sun6"
   default['java']['openjdk_packages'] = ["sun-jdk#{node['java']['jdk_version']}", "sun-jre#{node['java']['jdk_version']}"]


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3541

This request is technically a dupe of #43, but since I didn't feel comfortable opening a COOK ticket for someone else's pull, and I have no way of knowing whether or not all the committers on that pull have signed the CLA, I redid the work and opened this pull request. Feel free to close it in favor of #43.
