### PR TITLE
Ensure local directory hierarchy (suspect there is a better way).

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -69,7 +69,7 @@ def download_direct_from_oracle(tarball_name, new_resource)
     converge_by(description) do
        Chef::Log.debug "downloading oracle tarball straight from the source"
        cmd = shell_out!(
-                                  %Q[ curl -L --cookie "#{cookie}" #{new_resource.url} -o #{download_path} ]
+                                  %Q[ curl --create-dirs -L --cookie "#{cookie}" #{new_resource.url} -o #{download_path} ]
                                )
     end
   else


### PR DESCRIPTION
The java recipe consistently fails for me when run the first time. A subsequent `vagrant provision` succeeds.

I tracked the problem down to the failure of the curl of the jdk .tar.gz with error 23 - a write error. In turns out that the destination directory, `/var/chef/cache`, doesn't exist at that time. 

Not sure what, if anything, is supposed to create that directory, but getting using `curl --create-dirs` seems fairly innocuous.

I'm using a standard precise64.box and these attributes.

```
:java => {
  :install_flavor => "oracle",
  :oracle => {
     "accept_oracle_download_terms" => true
  },
:jdk_version => "7"
```
