### PR TITLE
[COOK-3668] Only issue notifies to update-java-alternatives after all java packages have been installed.

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -48,6 +48,8 @@ end
 node['java']['openjdk_packages'].each do |pkg|
   package pkg do
     action :install
-    notifies :run, 'bash[update-java-alternatives]', :immediately if platform_family?('debian', 'rhel', 'fedora')
+    if pkg == node['java']['openjdk_packages'].last
+      notifies :run, 'bash[update-java-alternatives]', :immediately if platform_family?('debian', 'rhel', 'fedora')
+    end
   end
 end


### PR DESCRIPTION
This patch fixes an order of operations problem with openjdk 7 packages on Ubuntu 12.04. This passed test-kitchen, however we should add a wrapper cookbook test case for setting the jdk version as it seems to be a recurring issue.
