### PR TITLE
[COOK-3704] Fix alternatives when the package is already installed

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -21,20 +21,6 @@
 
 java_location = Opscode::OpenJDK.new(node).java_location
 
-include_recipe 'java::set_java_home'
-
-if platform_family?('debian', 'rhel', 'fedora')
-
-  bash 'update-java-alternatives' do
-    code <<-EOH.gsub(/^\s+/, '')
-      update-alternatives --install /usr/bin/java java #{java_location} 1061 && \
-      update-alternatives --set java #{java_location}
-    EOH
-    action :nothing
-  end
-
-end
-
 if platform_requires_license_acceptance?
   file "/opt/local/.dlj_license_accepted" do
     owner "root"
@@ -46,10 +32,19 @@ if platform_requires_license_acceptance?
 end
 
 node['java']['openjdk_packages'].each do |pkg|
-  package pkg do
-    action :install
-    if pkg == node['java']['openjdk_packages'].last
-      notifies :run, 'bash[update-java-alternatives]', :immediately if platform_family?('debian', 'rhel', 'fedora')
-    end
+  package pkg
+end
+
+if platform_family?('debian', 'rhel', 'fedora')
+  bash 'update-java-alternatives' do
+    code <<-EOH.gsub(/^\s+/, '')
+      update-alternatives --install /usr/bin/java java #{java_location} 1061 && \
+      update-alternatives --set java #{java_location}
+    EOH
+    only_if "update-alternatives --display java | grep '#{java_location} - priority 1061'"
   end
 end
+
+# We must include this recipe AFTER updating the alternatives or else JAVA_HOME
+# will not point to the correct java.
+include_recipe 'java::set_java_home'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3704

The current Java cookbook uses a conditional notification on the package installation to notify the java alternatives to update. This actually makes it impossible to switch between java versions, because the default java being set is dependent on the package installation, not the value of the alternative.

This patch removes the notification and checks the current value of the alternative to see if it should be updated. This ensure that the correct Java is used, even if the package was already installed.
