### PR TITLE
[CHEF-4210] remove unneeded run_command to prevent zombie processes

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -226,7 +226,7 @@ action :install do
           description = "Set alternative for #{cmd}"
           converge_by(description) do
             Chef::Log.debug "Setting alternative for #{cmd}"
-            set_cmd = shell_out("update-alternatives --set #{cmd} #{alt_path}").run_command
+            set_cmd = shell_out("update-alternatives --set #{cmd} #{alt_path}")
             unless set_cmd.exitstatus == 0
               Chef::Application.fatal!(%Q[ set alternative failed ])
             end


### PR DESCRIPTION
This should fix the problem described in https://tickets.opscode.com/browse/CHEF-4210
