### PR TITLE
Moving configuration dependent on version/install_flavor to a recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,37 +27,6 @@ default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? "x86_64" : "i586"
 default['java']['openjdk_packages'] = []
 default['java']['accept_license_agreement'] = false
 
-case node['platform_family']
-when "rhel", "fedora"
-  default['java']['java_home'] = "/usr/lib/jvm/java"
-  default['java']['openjdk_packages'] = ["java-1.#{node['java']['jdk_version']}.0-openjdk", "java-1.#{node['java']['jdk_version']}.0-openjdk-devel"]
-when "freebsd"
-  default['java']['java_home'] = "/usr/local/openjdk#{node['java']['jdk_version']}"
-  default['java']['openjdk_packages'] = ["openjdk#{node['java']['jdk_version']}"]
-when "arch"
-  default['java']['java_home'] = "/usr/lib/jvm/java-#{node['java']['jdk_version']}-openjdk"
-  default['java']['openjdk_packages'] = ["openjdk#{node['java']['jdk_version']}}"]
-when "windows"
-  default['java']['install_flavor'] = "windows"
-  default['java']['windows']['url'] = nil
-  default['java']['windows']['checksum'] = nil
-  default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
-when "debian"
-  default['java']['java_home'] = "/usr/lib/jvm/java-#{node['java']['jdk_version']}-#{node['java']['install_flavor']}"
-  # Newer Debian & Ubuntu adds the architecture to the path
-  if node['platform'] == 'debian' && Chef::VersionConstraint.new(">= 7.0").include?(node['platform_version']) ||
-     node['platform'] == 'ubuntu' && Chef::VersionConstraint.new(">= 12.04").include?(node['platform_version'])
-    default['java']['java_home'] = "#{node['java']['java_home']}-#{node['kernel']['machine'] == 'x86_64' ? 'amd64' : 'i386'}"
-  end
-  default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk", "openjdk-#{node['java']['jdk_version']}-jre-headless"]
-when "smartos"
-  default['java']['java_home'] = "/opt/local/java/sun6"
-  default['java']['openjdk_packages'] = ["sun-jdk#{node['java']['jdk_version']}", "sun-jre#{node['java']['jdk_version']}"]
-else
-  default['java']['java_home'] = "/usr/lib/jvm/default-java"
-  default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk"]
-end
-
 case node['java']['install_flavor']
 when 'ibm'
   default['java']['ibm']['url'] = nil

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -1,0 +1,33 @@
+# Doing this configuration here instead of attributes/default.rb so that the user has the ability
+# to override node['java']['jdk_version'] and node['java']['install_flavor'] using a data bag
+# item, e.g. through bag_config.
+
+case node['platform_family']
+when "rhel", "fedora"
+  node.default['java']['java_home'] = "/usr/lib/jvm/java"
+when "freebsd"
+  node.default['java']['java_home'] = "/usr/local/openjdk#{node['java']['jdk_version']}"
+  node.default['java']['openjdk_packages'] = ["openjdk#{node['java']['jdk_version']}"]
+when "arch"
+  node.default['java']['java_home'] = "/usr/lib/jvm/java-#{node['java']['jdk_version']}-openjdk"
+  node.default['java']['openjdk_packages'] = ["openjdk#{node['java']['jdk_version']}}"]
+when "windows"
+  node.default['java']['install_flavor'] = "windows"
+  node.default['java']['windows']['url'] = nil
+  node.default['java']['windows']['checksum'] = nil
+  node.default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
+when "debian"
+  node.default['java']['java_home'] = "/usr/lib/jvm/java-#{node['java']['jdk_version']}-#{node['java']['install_flavor']}"
+  # Newer Debian & Ubuntu adds the architecture to the path
+  if node['platform'] == 'debian' && Chef::VersionConstraint.new(">= 7.0").include?(node['platform_version']) ||
+     node['platform'] == 'ubuntu' && Chef::VersionConstraint.new(">= 12.04").include?(node['platform_version'])
+    node.default['java']['java_home'] = "#{node['java']['java_home']}-#{node['kernel']['machine'] == 'x86_64' ? 'amd64' : 'i386'}"
+  end
+  node.default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk", "openjdk-#{node['java']['jdk_version']}-jre-headless"]
+when "smartos"
+  node.default['java']['java_home'] = "/opt/local/java/sun6"
+  node.default['java']['openjdk_packages'] = ["sun-jdk#{node['java']['jdk_version']}", "sun-jre#{node['java']['jdk_version']}"]
+else
+  node.default['java']['java_home'] = "/usr/lib/jvm/default-java"
+  node.default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk"]
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+include_recipe 'java::configuration'
 include_recipe "java::#{node['java']['install_flavor']}"
 
 # Purge the deprecated Sun Java packages if remove_deprecated_packages is true

--- a/recipes/ibm.rb
+++ b/recipes/ibm.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'java::configuration'
+
 require 'uri'
 source_url = node['java']['ibm']['url']
 jdk_uri = ::URI.parse(source_url)

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -19,6 +19,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'java::configuration'
+
 java_location = Opscode::OpenJDK.new(node).java_location
 
 if platform_requires_license_acceptance?

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'java::configuration'
 
 java_home = node['java']["java_home"]
 arch = node['java']['arch']

--- a/recipes/oracle_i386.rb
+++ b/recipes/oracle_i386.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'java::configuration'
+
 java_home = node['java']["java_home"]
 
 case node['java']['jdk_version']

--- a/recipes/oracle_rpm.rb
+++ b/recipes/oracle_rpm.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'java::configuration'
 include_recipe 'java::set_java_home'
 
 

--- a/recipes/set_java_home.rb
+++ b/recipes/set_java_home.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'java::configuration'
+
 ruby_block  "set-env-java-home" do
   block do
     ENV["JAVA_HOME"] = node['java']['java_home']

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+include_recipe 'java::configuration'
 require 'uri'
 
 Chef::Log.fatal("No download url set for java installer.") unless node['java'] && node['java']['windows'] && node['java']['windows']['url']


### PR DESCRIPTION
This is so that the user can override node['java']['jdk_version'] and
node['java']['install_flavor'] before they are used to compute other
attributes, such as openjdk_packages. This is necessary to make it
possible to override version/install_flavor in a data bag using the
bag_config cookbook.
