### PR TITLE
support for MD5 checksum

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -47,8 +47,13 @@ end
 def oracle_downloaded?(download_path, new_resource)
   if ::File.exists? download_path
     require 'digest'
-    downloaded_sha =  Digest::SHA256.file(download_path).hexdigest
-    downloaded_sha == new_resource.checksum
+    if new_resource.checksum =~ /^[0-9a-f]{32}$/
+      downloaded_sha =  Digest::MD5.file(download_path).hexdigest
+      downloaded_sha == new_resource.md5 
+    else
+      downloaded_sha =  Digest::SHA256.file(download_path).hexdigest
+      downloaded_sha == new_resource.checksum
+    end
   else
     return false
   end

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -21,7 +21,7 @@ actions :install, :remove
 
 attribute :url, :regex => /^(file|https?):\/\/.*(tar.gz|tgz|bin|zip)$/, :default => nil
 attribute :mirrorlist, :kind_of => Array, :default => nil
-attribute :checksum, :regex => /^[a-zA-Z0-9]{40,64}$/, :default => nil
+attribute :checksum, :regex => /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/, :default => nil
 attribute :app_home, :kind_of => String, :default => nil
 attribute :app_home_mode, :kind_of => Integer, :default => 0755
 attribute :bin_cmds, :kind_of => Array, :default => nil


### PR DESCRIPTION
Oracle provides MD5 checksum for jdk downloads: http://www.oracle.com/technetwork/java/javase/downloads/java-se-binaries-checksum-1956892.html
The cookbook currently only supports SHA256. This pull request parses the format of the checksum and automatically uses SHA256 or MD5 to verify the downloaded file. That way the checksum provided by oracle may be used directly, while maintaining support for SH256.
