### PR TITLE
Use escaped quotes for Windows INSTALLDIR

### DIFF
--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -52,7 +52,9 @@ end
 
 if node['java'].attribute?("java_home")
   java_home_win = win_friendly_path(node['java']['java_home'])
-  additional_options = "INSTALLDIR=\"#{java_home_win}\""
+  # The EXE installer expects escaped quotes, so we need to double escape
+  # them here.
+  additional_options = "INSTALLDIR=\\\"#{java_home_win}\\\""
 
   env "JAVA_HOME" do
     value java_home_win


### PR DESCRIPTION
When installing Java on Windows, the Java EXE installer expects that the INSTALLDIR variable to contain quotes if there are spaces in the path.  This means quotes need to be escaped on the command line.  For example, this does not work:

```
jre-1.7.0_45-windows-x64.exe /s INSTALLDIR="C:\Program Files\java\jre7"
```

but this does:

```
jre-1.7.0_45-windows-x64.exe /s INSTALLDIR=\"C:\Program Files\java\jre7\"
```

I suspect this is because they are passing the arguments as a string to the MSI.

Since the quotes need to be escaped on the command line, they need to be double escaped in Ruby.
