### PR TITLE
[COOK-4109] set alternatives when using ibm_tar recipe

### DIFF
--- a/providers/alternatives.rb
+++ b/providers/alternatives.rb
@@ -25,6 +25,11 @@ action :set do
       alt_path = "#{new_resource.java_location}/bin/#{cmd}"
       priority = new_resource.priority
 
+      if !::File.exist?(alt_path)
+        Chef::Log.debug "Skipping setting alternative for #{cmd}. Command #{alt_path} does not exist."
+        next
+      end
+
       # install the alternative if needed
       alternative_exists = shell_out("update-alternatives --display #{cmd} | grep #{alt_path}").exitstatus == 0
       unless alternative_exists

--- a/recipes/ibm_tar.rb
+++ b/recipes/ibm_tar.rb
@@ -48,9 +48,21 @@ directory "create-java-home" do
   recursive true
 end
 
+java_alternatives 'set-java-alternatives' do
+  java_location node['java']['java_home']
+  case node['java']['jdk_version']
+  when "6"
+    bin_cmds node['java']['ibm']['6']['bin_cmds']
+  when "7"
+    bin_cmds node['java']['ibm']['7']['bin_cmds']
+  end
+  action :nothing
+end
+
 execute "untar-ibm-java" do
   cwd Chef::Config[:file_cache_path]
   command "tar xzf ./#{jdk_filename} -C #{node['java']['java_home']} --strip 1"
+  notifies :set, 'java_alternatives[set-java-alternatives]', :immediately
   creates "#{node['java']['java_home']}/jre/bin/java"
 end
 


### PR DESCRIPTION
Ensure the command alternatives are setup when installing IBM JVM using the ibm_tar recipe. Also, skip over any non-existing commands when setting up alternatives.
