### PR TITLE
Specify windows attributes in attribute files

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,11 +21,20 @@
 default['java']['remove_deprecated_packages'] = false
 
 # default jdk attributes
-default['java']['install_flavor'] = "openjdk"
 default['java']['jdk_version'] = '6'
 default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? "x86_64" : "i586"
 default['java']['openjdk_packages'] = []
 default['java']['accept_license_agreement'] = false
+
+case node['platform_family']
+when "windows"
+  default['java']['install_flavor'] = "windows"
+  default['java']['windows']['url'] = nil
+  default['java']['windows']['checksum'] = nil
+  default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
+else
+  default['java']['install_flavor'] = "openjdk"
+end
 
 case node['java']['install_flavor']
 when 'ibm', 'ibm_tar'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,9 @@
 # limitations under the License.
 #
 
+# Calculate variables that depend on jdk_version
+# If you need to override this in an attribute file you must use
+# force_default or higher precedence.
 case node['platform_family']
 when "rhel", "fedora"
   node.default['java']['java_home'] = "/usr/lib/jvm/java"
@@ -28,11 +31,6 @@ when "freebsd"
 when "arch"
   node.default['java']['java_home'] = "/usr/lib/jvm/java-#{node['java']['jdk_version']}-openjdk"
   node.default['java']['openjdk_packages'] = ["openjdk#{node['java']['jdk_version']}}"]
-when "windows"
-  node.default['java']['install_flavor'] = "windows"
-  node.default['java']['windows']['url'] = nil
-  node.default['java']['windows']['checksum'] = nil
-  node.default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
 when "debian"
   node.default['java']['java_home'] = "/usr/lib/jvm/java-#{node['java']['jdk_version']}-#{node['java']['install_flavor']}"
   # Newer Debian & Ubuntu adds the architecture to the path


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/socrata/java/pull/95.  Setting attributes in the recipe (instead of the attribute file) prevents setting default attributes in wrapper cookbooks.  I realize this was done so users could easily override `jdk_version` without having to override all attributes that depend on `jdk_version`.

This ensures that only attributes which depend on `jdk_version` are set in the recipe.  All other attributes are set in the attribute file like normal.

This fixes windows installations where a user **must** specify a url and checksum.
