### PR TITLE
Fixed windows case to prevent bad java_home variable setting

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,6 +42,8 @@ when "debian"
 when "smartos"
   node.default['java']['java_home'] = "/opt/local/java/sun6"
   node.default['java']['openjdk_packages'] = ["sun-jdk#{node['java']['jdk_version']}", "sun-jre#{node['java']['jdk_version']}"]
+when "windows"
+  # Do nothing otherwise we will fall through to the else and set java_home to an invalid path, causing the installer to popup a dialog
 else
   node.default['java']['java_home'] = "/usr/lib/jvm/default-java"
   node.default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk"]


### PR DESCRIPTION
I encountered a bug in this version which caused a bad java_home node attribute to be set because of the case statement below (it would fall through to the else). That in turn caused a problem with the generated command which caused a popup, hanging chef-client runs. Below is a quick fix.
