### PR TITLE
Suggest windows and aws

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -31,5 +31,5 @@ recipe "java::oracle_rpm", "Installs the Oracle RPM flavor of Java"
   supports os
 end
 
-depends "windows"
-depends "aws"
+suggests "windows"
+suggests "aws"


### PR DESCRIPTION
Related to #92, it seems to me that full fledged dependencies on aws and windows is excessive for pure Linux environments. 

As suggested by @carmstrong, this change moves from depends to suggests for both aws and windows.

YMMV, but switching to suggests moved my chef setup from failing to compile (even though I cloned down the aws and windows cookbooks), to a working state where I am able to compile and run successfully.

If this patch is accepted, it should resolve #92 as well.
