### PR TITLE
Removes the attribute to purge deprecated packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Attributes
 
 See `attributes/default.rb` for default values.
 
-* `node['java']['remove_deprecated_packages']` - Removes the now
-deprecated Ubuntu JDK packages from the system, default `false`
 * `node['java']['install_flavor']` - Flavor of JVM you would like
 installed (`oracle`, `openjdk`, `ibm`, `windows`), default `openjdk`
 on Linux/Unix platforms, `windows` on Windows platforms.
@@ -151,7 +149,7 @@ this recipe requires you to host it internally on your own http repo.
 **IMPORTANT NOTE**
 
 If you use the `windows` recipe, you'll need to make sure you've uploaded
-the `aws` and `windows` cookbooks. As of version 1.18.0, this cookbook 
+the `aws` and `windows` cookbooks. As of version 1.18.0, this cookbook
 references them with `suggests` instead of `depends`, as they are only
 used by the `windows` recipe.
 
@@ -223,8 +221,8 @@ By default, the extracted directory is extracted to
 ## java_alternatives
 
 The `java_alternatives` LWRP uses `update-alternatives` command
-to set and unset command alternatives for various Java tools 
-such as java, javac, etc. 
+to set and unset command alternatives for various Java tools
+such as java, javac, etc.
 
 ### Actions
 
@@ -235,7 +233,7 @@ such as java, javac, etc.
 
 - `java_location`: Java installation location.
 - `bin_cmds`: array of Java tool names to set or unset alternatives on.
-- `default`: whether to set the Java tools as system default. Boolean, defaults to `true`. 
+- `default`: whether to set the Java tools as system default. Boolean, defaults to `true`.
 - `priority`: priority of the alternatives. Integer, defaults to `1061`.
 
 ### Examples
@@ -247,7 +245,7 @@ such as java, javac, etc.
         action :set
     end
 
-### 
+###
 Usage
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,9 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# remove the deprecated Ubuntu jdk packages
-default['java']['remove_deprecated_packages'] = false
-
 # default jdk attributes
 default['java']['jdk_version'] = '6'
 default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? "x86_64" : "i586"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,3 @@
 
 include_recipe "java::compute_paths"
 include_recipe "java::#{node['java']['install_flavor']}"
-
-if node['java']['remove_deprecated_packages']
-  include_recipe "java::purge_packages"
-end

--- a/recipes/purge_packages.rb
+++ b/recipes/purge_packages.rb
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Purge the deprecated Sun Java packages if remove_deprecated_packages is true
 %w[sun-java6-jdk sun-java6-bin sun-java6-jre].each do |pkg|
   package pkg do
     action :purge


### PR DESCRIPTION
As the Sun packages purged by the cookbook are now ancient, most people won't need this functionality. Even if they do, they can now include the `purge_packages` recipe directly. 
