### PR TITLE
Add safety check if attributes are unset

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -20,7 +20,14 @@
 # limitations under the License.
 
 unless node.recipe?('java::default')
-  Chef::Log.warn("Using java::default instead is recommended")
+  Chef::Log.warn("Using java::default instead is recommended.")
+
+  # Even if this recipe is included by itself, a safety check is nice...
+  [ node['java']['openjdk_packages'], node['java']['java_home'] ].each do |v|
+    if v.nil? or v.empty?
+      include_recipe "java::set_attributes_from_version"
+    end
+  end
 end
 
 jdk = Opscode::OpenJDK.new(node)

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -18,7 +18,12 @@
 # limitations under the License.
 
 unless node.recipe?('java::default')
-  Chef::Log.warn("Using java::default instead is recommended")
+  Chef::Log.warn("Using java::default instead is recommended.")
+
+# Even if this recipe is included by itself, a safety check is nice...
+  if node['java']['java_home'].nil? or node['java']['java_home'].empty?
+    include_recipe "java::set_attributes_from_version"
+  end
 end
 
 java_home = node['java']["java_home"]

--- a/recipes/oracle_i386.rb
+++ b/recipes/oracle_i386.rb
@@ -18,7 +18,12 @@
 # limitations under the License.
 
 unless node.recipe?('java::default')
-  Chef::Log.warn("Using java::default instead is recommended")
+  Chef::Log.warn("Using java::default instead is recommended.")
+
+# Even if this recipe is included by itself, a safety check is nice...
+  if node['java']['java_home'].nil? or node['java']['java_home'].empty?
+    include_recipe "java::set_attributes_from_version"
+  end
 end
 
 java_home = node['java']["java_home"]


### PR DESCRIPTION
Since users may still be using the install flavor recipes directly instead of the default recipe, we check `java_home` and conditionally `openjdk_packages` and include `set_attributes_from_version` if these are `nil`.
