### PR TITLE
Update to use newer version of ChefSpec (~> 3.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 2.0'
-gem 'chefspec',   '~> 2.0'
+gem 'chefspec',   '~> 3.1'
 gem 'foodcritic', '~> 3.0'
 gem 'rubocop',    '~> 0.12'
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'java::default' do
   let(:chef_run) do
-    runner = ChefSpec::ChefRunner.new(
+    runner = ChefSpec::Runner.new(
       :platform => 'debian',
       :version => '7.0'
     )
-    runner.converge('java::default')
+    runner.converge(described_recipe)
   end
   it 'should include the openjdk recipe by default' do
     expect(chef_run).to include_recipe('java::openjdk')
@@ -14,13 +14,13 @@ describe 'java::default' do
 
   context 'windows' do
     let(:chef_run) do
-      runner = ChefSpec::ChefRunner.new(
+      runner = ChefSpec::Runner.new(
         'platform' => 'windows',
         'version' => '2008R2'
       )
       runner.node.set['java']['install_flavor'] = 'windows'
       runner.node.set['java']['windows']['url'] = 'http://example.com/windows-java.msi'
-      runner.converge('java::default')
+      runner.converge(described_recipe)
     end
 
     it 'should include the windows recipe' do
@@ -30,9 +30,9 @@ describe 'java::default' do
 
   context 'oracle' do
     let(:chef_run) do
-      runner = ChefSpec::ChefRunner.new
+      runner = ChefSpec::Runner.new
       runner.node.set['java']['install_flavor'] = 'oracle'
-      runner.converge('java::default')
+      runner.converge(described_recipe)
     end
 
     it 'should include the oracle recipe' do
@@ -42,9 +42,9 @@ describe 'java::default' do
 
   context 'oracle_i386' do
     let(:chef_run) do
-      runner = ChefSpec::ChefRunner.new
+      runner = ChefSpec::Runner.new
       runner.node.set['java']['install_flavor'] = 'oracle_i386'
-      runner.converge('java::default')
+      runner.converge(described_recipe)
     end
 
     it 'should include the oracle_i386 recipe' do
@@ -54,10 +54,10 @@ describe 'java::default' do
 
   context 'ibm' do
     let(:chef_run) do
-      runner = ChefSpec::ChefRunner.new
+      runner = ChefSpec::Runner.new
       runner.node.set['java']['install_flavor'] = 'ibm'
       runner.node.set['java']['ibm']['url'] = 'http://example.com/ibm-java.bin'
-      runner.converge('java::default')
+      runner.converge(described_recipe)
     end
 
     it 'should include the ibm recipe' do
@@ -67,10 +67,10 @@ describe 'java::default' do
 
   context 'ibm_tar' do
     let(:chef_run) do
-      runner = ChefSpec::ChefRunner.new
+      runner = ChefSpec::Runner.new
       runner.node.set['java']['install_flavor'] = 'ibm_tar'
       runner.node.set['java']['ibm']['url'] = 'http://example.com/ibm-java.tar.gz'
-      runner.converge('java::default')
+      runner.converge(described_recipe)
     end
 
     it 'should include the ibm_tar recipe' do

--- a/spec/ibm_spec.rb
+++ b/spec/ibm_spec.rb
@@ -1,17 +1,21 @@
 require 'spec_helper'
 
 describe 'java::ibm' do
+  before do
+    Chef::Config[:file_cache_path] = '/var/chef/cache'
+  end
+
   let(:chef_run) do
-    runner = ChefSpec::ChefRunner.new
+    runner = ChefSpec::Runner.new
     runner.node.set['java']['install_flavor'] = 'ibm'
     runner.node.set['java']['ibm']['url'] = 'http://example.com/ibm-java.bin'
     runner.node.set['java']['ibm']['checksum'] = 'deadbeef'
     runner.node.set['java']['ibm']['accept_ibm_download_terms'] = true
-    runner.converge('java::ibm')
+    runner.converge(described_recipe)
   end
 
   it 'creates an installer.properties file' do
-    expect(chef_run).to create_file('/var/chef/cache/installer.properties')
+    expect(chef_run).to create_template('/var/chef/cache/installer.properties')
   end
 
   it 'downloads the remote jdk file' do
@@ -19,7 +23,13 @@ describe 'java::ibm' do
   end
 
   it 'runs the installer' do
-    expect(chef_run).to execute_command('./ibm-java.bin -f ./installer.properties -i silent')
+    expect(chef_run).to run_execute('install-ibm-java').with(
+      :command => './ibm-java.bin -f ./installer.properties -i silent',
+      :creates => '/opt/ibm/java/jre/bin/java'
+    )
+
+    install_command = chef_run.execute('install-ibm-java')
+    expect(install_command).to notify('java_alternatives[set-java-alternatives]')
   end
 
   it 'includes the set_java_home recipe' do
@@ -28,7 +38,7 @@ describe 'java::ibm' do
 
   context 'install on ubuntu' do
     let(:chef_run) do
-      runner = ChefSpec::ChefRunner.new(:platform => 'ubuntu', :version => '12.04')
+      runner = ChefSpec::Runner.new(:platform => 'ubuntu', :version => '12.04')
       runner.node.set['java']['install_flavor'] = 'ibm'
       runner.node.set['java']['ibm']['checksum'] = 'deadbeef'
       runner.node.set['java']['ibm']['accept_ibm_download_terms'] = true
@@ -50,7 +60,7 @@ describe 'java::ibm' do
 
   context 'install on centos' do
     let(:chef_run) do
-      runner = ChefSpec::ChefRunner.new(:platform => 'centos', :version => '5.8')
+      runner = ChefSpec::Runner.new(:platform => 'centos', :version => '5.8')
       runner.node.set['java']['install_flavor'] = 'ibm'
       runner.node.set['java']['ibm']['checksum'] = 'deadbeef'
       runner.node.set['java']['ibm']['accept_ibm_download_terms'] = true

--- a/spec/ibm_tar_spec.rb
+++ b/spec/ibm_tar_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe 'java::ibm_tar' do
   let(:chef_run) do
-    runner = ChefSpec::ChefRunner.new
+    runner = ChefSpec::Runner.new
     runner.node.set['java']['java_home'] = '/home/java'
     runner.node.set['java']['install_flavor'] = 'ibm'
     runner.node.set['java']['ibm']['url'] = 'http://example.com/ibm-java.tar.gz'
     runner.node.set['java']['ibm']['checksum'] = 'deadbeef'
-    runner.converge('java::ibm_tar')
+    runner.converge(described_recipe)
   end
 
   it 'downloads the remote jdk file' do
@@ -19,7 +19,13 @@ describe 'java::ibm_tar' do
   end
 
   it 'untar the jdk file' do
-    expect(chef_run).to execute_command('tar xzf ./ibm-java.tar.gz -C /home/java --strip 1')
+    expect(chef_run).to run_execute('untar-ibm-java').with(
+      :command => 'tar xzf ./ibm-java.tar.gz -C /home/java --strip 1',
+      :creates => '/home/java/jre/bin/java'
+    )
+
+    untar_command = chef_run.execute('untar-ibm-java')
+    expect(untar_command).to notify('java_alternatives[set-java-alternatives]')
   end
 
   it 'includes the set_java_home recipe' do

--- a/spec/openjdk_spec.rb
+++ b/spec/openjdk_spec.rb
@@ -22,7 +22,7 @@ describe 'java::openjdk' do
   # Regression test for COOK-2989
   context 'update-java-alternatives' do
     let(:chef_run) do
-      ChefSpec::ChefRunner.new(:platform => 'ubuntu', :version => '12.04').converge('java::openjdk')
+      ChefSpec::Runner.new(:platform => 'ubuntu', :version => '12.04').converge(described_recipe)
     end
 
     it 'executes update-java-alternatives with the right commands' do
@@ -32,7 +32,7 @@ describe 'java::openjdk' do
       update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-6-openjdk-amd64/jre/bin/java 1061 && \
       update-alternatives --set java /usr/lib/jvm/java-6-openjdk-amd64/jre/bin/java
       EOH
-      expect(chef_run).to execute_bash_script('update-java-alternatives').with(:code => code_string)
+      expect(chef_run).to run_bash('update-java-alternatives').with(:code => code_string)
     end
   end
 
@@ -40,7 +40,7 @@ describe 'java::openjdk' do
     data['versions'].each do |version|
       context "On #{platform} #{version}" do
         let(:chef_run) do
-          ChefSpec::ChefRunner.new(:platform => platform, :version => version).converge('java::openjdk')
+          ChefSpec::Runner.new(:platform => platform, :version => version).converge(described_recipe)
         end
 
         data['packages'].each do |pkg|
@@ -61,7 +61,7 @@ describe 'java::openjdk' do
     {'centos' => '6.3','ubuntu' => '12.04'}.each_pair do |platform, version|
       context platform do
         let(:chef_run) do
-          ChefSpec::ChefRunner.new(:platform => platform, :version => version).converge('java::openjdk')
+          ChefSpec::Runner.new(:platform => platform, :version => version).converge('java::openjdk')
         end
 
         it 'does not write out license file' do
@@ -72,7 +72,7 @@ describe 'java::openjdk' do
 
     context 'smartos' do
       let(:chef_run) do
-        ChefSpec::ChefRunner.new(:platform => 'smartos', :version => 'joyent_20130111T180733Z', :evaluate_guards => true)
+        ChefSpec::Runner.new(:platform => 'smartos', :version => 'joyent_20130111T180733Z', :evaluate_guards => true)
       end
 
       context 'when auto_accept_license is true' do

--- a/spec/oracle_i386_spec.rb
+++ b/spec/oracle_i386_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'java::oracle_i386' do
   let(:chef_run) do
-    runner = ChefSpec::ChefRunner.new
-    runner.converge('java::oracle_i386')
+    runner = ChefSpec::Runner.new
+    runner.converge(described_recipe)
   end
 
   it 'should include the set_java_home recipe' do

--- a/spec/oracle_spec.rb
+++ b/spec/oracle_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'java::oracle' do
   let(:chef_run) do
-    runner = ChefSpec::ChefRunner.new
-    runner.converge('java::oracle')
+    runner = ChefSpec::Runner.new
+    runner.converge(described_recipe)
   end
 
   it 'should include the set_java_home recipe' do

--- a/spec/set_java_home_spec.rb
+++ b/spec/set_java_home_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'java::set_java_home' do
   let(:chef_run) do
-    runner = ChefSpec::ChefRunner.new
+    runner = ChefSpec::Runner.new
     runner.node.set['java']['java_home'] = '/opt/java'
     runner.converge('java::set_java_home')
   end

--- a/spec/windows_spec.rb
+++ b/spec/windows_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'java::windows' do
-  let(:chef_run) { ChefSpec::ChefRunner.new.converge 'java::windows' }
+  let(:chef_run) { ChefSpec::Runner.new.converge described_recipe }
   it 'should do something' do
     pending 'Your recipe examples go here.'
   end


### PR DESCRIPTION
Update to use ChefSpec ~> 3.1. There are still a bunch of tests failing, but this puts the cookbook in a better position. Most of the failures are now due to the refactoring of the openjdk recipe I believe.

Sorry I am not able to do anymore, but I gotta get back to some work stuff for the rest of the day!
