### PR TITLE
Fix JDK install on Windows.

### DIFF
--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -53,8 +53,9 @@ end
 if node['java'].attribute?("java_home")
   java_home_win = win_friendly_path(node['java']['java_home'])
   # The EXE installer expects escaped quotes, so we need to double escape
-  # them here.
-  additional_options = "INSTALLDIR=\\\"#{java_home_win}\\\""
+  # them here. The final string looks like :
+  # /v"/qn INSTALLDIR=\"C:\Program Files\Java\""
+  additional_options = "/v\"/qn INSTALLDIR=\\\"#{java_home_win}\\\"\""
 
   env "JAVA_HOME" do
     value java_home_win


### PR DESCRIPTION
I think that https://github.com/socrata-cookbooks/java/pull/100 broke the windows install when using a JDK installer.

For example, if I download both a JRE and a JDK here : http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html and here http://java.com/en/download/manual.jsp#win
and then run both

.\jdk-7u51-windows-x64.exe /s INSTALLDIR=\"C:\java\"
and 
.\jre-7u51-windows-x64.exe /s INSTALLDIR=\"C:\java\"

The second one works, but the first one doesn't. It does when I remove the backward slashes. 

The fix seems to be http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4966488

I tested this change with both a JDK and a JRE installer, and both were correctly installed.
