### PR TITLE
Allow jdk_version to be a string or number

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -27,7 +27,7 @@ module Opscode
     def initialize(node)
       @node = node.to_hash
       @java_home = @node['java']['java_home'] || '/usr/lib/jvm/default-java'
-      @jdk_version = @node['java']['jdk_version'] || '6'
+      @jdk_version = @node['java']['jdk_version'].to_s || '6'
     end
 
     def java_location

--- a/recipes/ibm.rb
+++ b/recipes/ibm.rb
@@ -52,7 +52,7 @@ end
 
 java_alternatives 'set-java-alternatives' do
   java_location node['java']['java_home']
-  case node['java']['jdk_version']
+  case node['java']['jdk_version'].to_s
   when "6"
     bin_cmds node['java']['ibm']['6']['bin_cmds']
   when "7"

--- a/recipes/ibm_tar.rb
+++ b/recipes/ibm_tar.rb
@@ -50,7 +50,7 @@ end
 
 java_alternatives 'set-java-alternatives' do
   java_location node['java']['java_home']
-  case node['java']['jdk_version']
+  case node['java']['jdk_version'].to_s
   when "6"
     bin_cmds node['java']['ibm']['6']['bin_cmds']
   when "7"

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -50,7 +50,7 @@ if platform_family?('debian', 'rhel', 'fedora')
   java_alternatives 'set-java-alternatives' do
     java_location jdk.java_home
     priority jdk.alternatives_priority
-    case node['java']['jdk_version']
+    case node['java']['jdk_version'].to_s
     when "6"
       bin_cmds node['java']['jdk']['6']['bin_cmds']
     when "7"

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -28,14 +28,8 @@ end
 
 java_home = node['java']["java_home"]
 arch = node['java']['arch']
-jdk_version = node['java']['jdk_version']
 
-#convert version number to a string if it isn't already
-if jdk_version.instance_of? Fixnum
-  jdk_version = jdk_version.to_s
-end
-
-case jdk_version
+case node['java']['jdk_version'].to_s
 when "6"
   tarball_url = node['java']['jdk']['6'][arch]['url']
   tarball_checksum = node['java']['jdk']['6'][arch]['checksum']

--- a/recipes/oracle_i386.rb
+++ b/recipes/oracle_i386.rb
@@ -28,7 +28,7 @@ end
 
 java_home = node['java']["java_home"]
 
-case node['java']['jdk_version']
+case node['java']['jdk_version'].to_s
 when "6"
   tarball_url = node['java']['jdk']['6']['i586']['url']
   tarball_checksum = node['java']['jdk']['6']['i586']['checksum']

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -23,7 +23,7 @@ describe Opscode::OpenJDK do
     {
       'java' => {
         'java_home' => '/usr/lib/jvm/default-java',
-        'jdk_version' => 6
+        'jdk_version' => '6'
       },
       'kernel' => {
         'machine' => 'x86_64'


### PR DESCRIPTION
Previously, the case statements checking the jdk_version failed
because they were assuming jdk_version was a string. For users overriding
this value and setting it to be a number, the case statement would never
match. This commit ensures we are always using a string when comparing
jdk_version.
