### PR TITLE
Create /usr/lib/jvm/default-java on Debian

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -60,6 +60,13 @@ if platform_family?('debian', 'rhel', 'fedora')
   end
 end
 
+if platform_family?('debian')
+  link '/usr/lib/jvm/default-java' do
+    to node['java']['java_home']
+    not_if { node['java']['java_home'] == '/usr/lib/jvm/default-java' }
+  end
+end
+
 # We must include this recipe AFTER updating the alternatives or else JAVA_HOME
 # will not point to the correct java.
 include_recipe 'java::set_java_home'


### PR DESCRIPTION
This is not happening by default on Ubuntu:
https://bugs.launchpad.net/ubuntu/+source/java-common/+bug/687263
