### PR TITLE
added case to set java_home correctly for oracle_rpm

### DIFF
--- a/recipes/set_attributes_from_version.rb
+++ b/recipes/set_attributes_from_version.rb
@@ -22,6 +22,8 @@ when "rhel", "fedora"
   case node['java']['install_flavor']
   when "oracle"
     node.default['java']['java_home'] = "/usr/lib/jvm/java"
+  when "oracle_rpm"
+    node.default['java']['java_home'] = "/usr/java/latest"
   else
     node.default['java']['java_home'] = "/usr/lib/jvm/java-1.#{node['java']['jdk_version']}.0"
   end


### PR DESCRIPTION
Without explicitly setting this for the oracle_rpm install, it sets java_home to /usr/lib/jvm/java-1.<version>.0.  The oracle rpm installation doesn't exist there.  Added a case for oracle_rpm to set java_home appropriately.
