### PR TITLE
Update Oracle accept-license-terms cookie format

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -62,7 +62,7 @@ end
 def download_direct_from_oracle(tarball_name, new_resource)
   download_path = "#{Chef::Config[:file_cache_path]}/#{tarball_name}"
   jdk_id = new_resource.url.scan(/\/([6789]u[0-9][0-9]?-b[0-9][0-9])\//)[0][0]
-  cookie = "oraclelicensejdk-#{jdk_id}-oth-JPR=accept-securebackup-cookie;gpw_e24=http://edelivery.oracle.com"
+  cookie = "oraclelicense=accept-securebackup-cookie"
   if node['java']['oracle']['accept_oracle_download_terms']
     # install the curl package
     p = package "curl" do


### PR DESCRIPTION
Oracle's download site no longer seems to accept the old cookie format.
