### PR TITLE
Remove VirtualBox specific box_urls

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: vagrant
+  require_chef_omnibus: true
   customize:
     memory: 1024
 


### PR DESCRIPTION
The Vagrant driver for Test Kitchen can automatically detect provisioner type and associated Bento box based on suite name.

See also: https://github.com/test-kitchen/kitchen-vagrant/blob/v0.14.0/lib/kitchen/driver/vagrant.rb#L108-L114

/cc @juliandunn
