### PR TITLE
default: don't fail when using java 8 on windows

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,8 +18,10 @@
 # limitations under the License.
 #
 
-if node['java']['jdk_version'].to_i == 8 and node['java']['install_flavor'] != 'oracle'
-  Chef::Application.fatal!("JDK 8 is currently only provided with the Oracle JDK")
+if node['java']['install_flavor'] != 'windows'
+  if node['java']['jdk_version'].to_i == 8 and node['java']['install_flavor'] != 'oracle'
+    Chef::Application.fatal!("JDK 8 is currently only provided with the Oracle JDK")
+  end
 end
 
 include_recipe "java::set_attributes_from_version"


### PR DESCRIPTION
I attempted to add an rspec test for this, but I wasn't able to get it working due to the windows recipe failing in tests in general (not just for this).
