### PR TITLE
Change ownership of extracted files

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -166,6 +166,9 @@ action :install do
        unless cmd.exitstatus == 0
            Chef::Application.fatal!(%Q[ Command \' mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" \' failed ])
          end
+
+       # change ownership of extracted files
+       FileUtils.chown_R new_resource.owner, new_resource.owner, app_root
      end
      new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
Change ownership of all extracted JDK files to the user and group as
specified by the attribute 'owner'. Otherwise the ownership of these
files is set to some random UID/GID as found in original archive (e.g.
all files in jdk-7u55-linux-x64.tar are set to UID=10 and GID=143).

Signed-off-by: Gregor Zurowski gregor@zurowski.org
