### PR TITLE
Allow for alternatives priority to be set from attribute.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? "x86_64" : "i586"
 default['java']['openjdk_packages'] = []
 default['java']['accept_license_agreement'] = false
 default['java']['set_default'] = true
+default['java']['alternatives_priority'] = 1062
 
 # the following retry parameters apply when downloading oracle java
 default['java']['ark_retries'] = 0

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -56,7 +56,7 @@ java_ark "jdk" do
   checksum tarball_checksum
   app_home java_home
   bin_cmds bin_cmds
-  alternatives_priority 1062
+  alternatives_priority node['java']['alternatives_priority']
   retries node['java']['ark_retries']
   retry_delay node['java']['ark_retry_delay']
   action :install


### PR DESCRIPTION
I have a situation where my base VM image already has OpenJDK installed and its alternatives priority is at something higher than 1062. In order for the Java installed by this cookbook to be used I need to increase the alternatives priority which isn't currently possible given that it is hardcoded at 1062. So, this patch makes it so the alternatives priority is configurable via an attribute.
