### PR TITLE
Skip install if already installed

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,6 +19,20 @@ require 'chef/version_constraint'
 require 'uri'
 require 'pathname'
 
+
+module Java
+  module Helper
+    # Check if Java is installed
+    def is_java_installed?()
+      case node['platform_family']
+      when 'windows'
+        File.exists?(File.join(node['java']['java_home'], '\bin\java.exe').gsub("/","\\"))
+      end
+    end
+  end
+end
+
+
 module Opscode
   class OpenJDK
 

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -17,8 +17,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+::Chef::Recipe.send(:include, Java::Helper)
 require 'uri'
+
+## Check if the Java is installed and exit if it is already installed.
+java_is_installed = is_java_installed?()
+Chef::Log.info("Java already installed at #{node['java']['java_home']}... Exiting") if java_is_installed
+return if java_is_installed
 
 Chef::Log.fatal("No download url set for java installer.") unless node['java'] && node['java']['windows'] && node['java']['windows']['url']
 


### PR DESCRIPTION
The default windows recipe install Java regardless if it is already
installed. Adding code to check if the Java.exe exist and exiting if it
exist.s
