### PR TITLE
increasing the timeout for downloading oracle java

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -54,7 +54,7 @@ def oracle_downloaded?(download_path, new_resource)
     require 'digest'
     if new_resource.checksum =~ /^[0-9a-f]{32}$/
       downloaded_sha =  Digest::MD5.file(download_path).hexdigest
-      downloaded_sha == new_resource.md5 
+      downloaded_sha == new_resource.md5
     else
       downloaded_sha =  Digest::SHA256.file(download_path).hexdigest
       downloaded_sha == new_resource.checksum
@@ -78,7 +78,7 @@ def download_direct_from_oracle(tarball_name, new_resource)
     converge_by(description) do
        Chef::Log.debug "downloading oracle tarball straight from the source"
        cmd = shell_out!(
-                                  %Q[ curl --create-dirs -L --retry #{new_resource.retries} --retry-delay #{new_resource.retry_delay} --cookie "#{cookie}" #{new_resource.url} -o #{download_path} ]
+                                  %Q[ curl --create-dirs -L --retry #{new_resource.retries} --retry-delay #{new_resource.retry_delay} --cookie "#{cookie}" #{new_resource.url} -o #{download_path} --connect-timeout #{new_resource.connect_timeout} ]
                                )
     end
   else

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -42,6 +42,7 @@ attribute :default, :equal_to => [true, false], :default => true
 attribute :alternatives_priority, :kind_of => Integer, :default => 1
 attribute :retries, :kind_of => Integer, :default => 0
 attribute :retry_delay, :kind_of => Integer, :default => 2
+attribute :connect_timeout, :kind_of => Integer, :default => 600 # => 10 minutes
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name


### PR DESCRIPTION
The default curl timeout on my system was 10 minutes (600s). This was resulting in timeouts when attempting to install oracle over a slow connection. The new timeout should allow much slower connections to successfully install oracle java.
