### PR TITLE
Fix failures when installing java on vagrant with vagrant-cachier plugin

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -153,7 +153,7 @@ action :install do
          end
        when /^.*\.(tar.gz|tgz)/
          cmd = shell_out(
-                            %Q[ tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{Chef::Config[:file_cache_path]}" ]
+                            %Q[ tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{Chef::Config[:file_cache_path]}" --no-same-owner]
                                   )
          unless cmd.exitstatus == 0
            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")


### PR DESCRIPTION
There are 2 issues here:
1. Even with the vagrant-cachier(https://github.com/fgrehm/vagrant-cachier) plugin, the java cookbook will always download java tarball anyway despite that the file is in cache folder already.
2. As the /var/chef/cache folder is mounted via NFS, there will be failures to set the permission to the extracted file.
