### PR TITLE
Use command_timeout attribute in java_ark specified by new node

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,7 @@ default['java']['set_etc_environment'] = false
 # the following retry parameters apply when downloading oracle java
 default['java']['ark_retries'] = 0
 default['java']['ark_retry_delay'] = 2
+default['java']['ark_timeout'] = 600
 
 case node['platform_family']
 when "windows"

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -59,6 +59,7 @@ java_ark "jdk" do
   alternatives_priority node['java']['alternatives_priority']
   retries node['java']['ark_retries']
   retry_delay node['java']['ark_retry_delay']
+  connect_timeout node['java']['ark_timeout']
   action :install
 end
 


### PR DESCRIPTION
attribute ['java']['ark_timeout']. Default 600 seconds. Because
downloading java from oracle can take longer than 10 minutes.

I tried running tests and most the test kitchen ones passed but then my laptop fell asleep. And the rspec tests aren't working anymore with the version of chef and chefspec on my machine. Tried running in the context of `bundle exec` but that didn't seem to help. Can't imagine how this would cause any issues since it effectively just makes the default behavior explicit and gives folks who wrap this cookbook the option to change the timeout. 
