### PR TITLE
Handle 'default' homebrew version

### DIFF
--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -5,11 +5,11 @@ include_recipe 'java::notify'
 homebrew_tap 'caskroom/versions'
 
 cask_default_java_version = '8'
-if node['java']['jdk_version'].to_s == cask_default_java_version
-  pkg_name = 'java'
-else
-  pkg_name = "java#{node['java']['jdk_version']}"
-end
+pkg_name = if node['java']['jdk_version'].to_s == cask_default_java_version
+             'java'
+           else
+             "java#{node['java']['jdk_version']}"
+           end
 
 if node['java']['jdk_version'].to_s == '7'
   log 'java-7-cask-removed' do

--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -3,6 +3,21 @@ include_recipe 'homebrew::cask'
 include_recipe 'java::notify'
 
 homebrew_tap 'caskroom/versions'
-homebrew_cask "java#{node['java']['jdk_version']}" do
+
+cask_default_java_version = '8'
+if node['java']['jdk_version'].to_s == cask_default_java_version
+  pkg_name = 'java'
+else
+  pkg_name = "java#{node['java']['jdk_version']}"
+end
+
+if node['java']['jdk_version'].to_s == '7'
+  log 'java-7-cask-removed' do
+    message 'java7 has been removed from caskroom/versions. See https://github.com/caskroom/homebrew-versions/pull/3914'
+    level :warn
+  end
+end
+
+homebrew_cask pkg_name do
   notifies :write, 'log[jdk-version-changed]', :immediately
 end


### PR DESCRIPTION
* Java 8 is the 'default' Caskroom cask, i.e. there is no 'java8' cask, it's 'java'
* Add warning that java7 was removed from caskroom/versions

---

I wasn't sure how you did macOS testing with `.kitchen.macos.yml`, so I didn't add/modify any existing tests (yet). 