### PR TITLE
Avoid EmptyWindowsCommand error on Windows for the commands tar, mv, unzip, ...

### DIFF
--- a/resources/oracle_install.rb
+++ b/resources/oracle_install.rb
@@ -87,7 +87,7 @@ action :install do
       case tarball_name
       when /^.*\.bin/
         cmd = shell_out(
-          %( cd "#{Chef::Config[:file_cache_path]}";
+          %(cd "#{Chef::Config[:file_cache_path]}";
               bash ./#{tarball_name} -noregister
             )
         )
@@ -96,7 +96,7 @@ action :install do
         end
       when /^.*\.zip/
         cmd = shell_out(
-          %( unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{Chef::Config[:file_cache_path]}" )
+          %(unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{Chef::Config[:file_cache_path]}" )
         )
         unless cmd.exitstatus == 0
           Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
@@ -108,7 +108,7 @@ action :install do
         end.run_action(:install)
 
         cmd = shell_out(
-          %( tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{Chef::Config[:file_cache_path]}" --no-same-owner)
+          %(tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{Chef::Config[:file_cache_path]}" --no-same-owner)
         )
         unless cmd.exitstatus == 0
           Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
@@ -116,7 +116,7 @@ action :install do
       end
 
       cmd = shell_out(
-        %( mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" )
+        %(mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" )
       )
       unless cmd.exitstatus == 0
         Chef::Application.fatal!(%( Command \' mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" \' failed ))
@@ -252,7 +252,7 @@ action_class do
       converge_by('download oracle tarball straight from the server') do
         Chef::Log.debug 'downloading oracle tarball straight from the source'
         shell_out!(
-          %( curl --create-dirs -L --retry #{new_resource.retries} --retry-delay #{new_resource.retry_delay} --cookie "#{cookie}" #{new_resource.url} -o #{download_path} --connect-timeout #{new_resource.connect_timeout} #{proxy} ),
+          %(curl --create-dirs -L --retry #{new_resource.retries} --retry-delay #{new_resource.retry_delay} --cookie "#{cookie}" #{new_resource.url} -o #{download_path} --connect-timeout #{new_resource.connect_timeout} #{proxy} ),
                                    timeout: new_resource.download_timeout
         )
       end


### PR DESCRIPTION
When I try to install Oracle JRE on Windows with the resource `oracle_install` the following error happends:
```
java_oracle_install[jre] had an error: Mixlib::ShellOut::EmptyWindowsCommand: could not parse script/executable out of command: ` tar xvzf "c:/chef/cache/jre-8u131-windows-x64.tar.gz" -C "c:/chef/cache" --no-same-owner`
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/mixlib-shellout-2.3.2-universal-mingw32/lib/mixlib/shellout/windows.rb:197:in `command_to_run'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/mixlib-shellout-2.3.2-universal-mingw32/lib/mixlib/shellout/windows.rb:61:in `run_command'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/mixlib-shellout-2.3.2-universal-mingw32/lib/mixlib/shellout.rb:263:in `run_command'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.8.5-universal-mingw32/lib/chef/mixin/shell_out.rb:171:in `shell_out_command'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.8.5-universal-mingw32/lib/chef/mixin/shell_out.rb:114:in `shell_out'
```

I think the cause is in the function `candidate_executable_for_command` from the mixin library `mixlib-shellout` in https://github.com/chef/mixlib-shellout/blob/master/lib/mixlib/shellout/windows.rb,
thus I have proposed a Pull Request to fix it: https://github.com/chef/mixlib-shellout/pull/155

The problem is with the heading space, I guess this space is just here for readability?

A workaround which works for me it's just removing the heading space (for all commands: tar, mv, unzip).
