### PR TITLE
Java 10 installation for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
+## [UNRELEASED]
+### Updated
+- Update oracle recipe to not perform a switch on java major version and instead
+use the version provided in attributes. This allows end users to include new Java
+versions without the cookbook requiring an update each time a major version gets
+released
+- Updated the oracle_install resource to pick up semantic versioning that Oracle
+has started using for Java 10+
+- Updated the default attributes file to include x86_64 endpoint and checksum for
+Oracle Java 10. The i586 version is not (yet) available. 
+
 ## v2.0.1 - (2018-05-02)
 
 - Fix java_certificate and java_oracle_install to work on FIPS enabled systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## [UNRELEASED]
 ### Updated
+- Added Java 10 JCE attributes to default attrs
 - Update oracle recipe to not perform a switch on java major version and instead
 use the version provided in attributes. This allows end users to include new Java
 versions without the cookbook requiring an update each time a major version gets
@@ -11,7 +12,7 @@ released
 - Updated the oracle_install resource to pick up semantic versioning that Oracle
 has started using for Java 10+
 - Updated the default attributes file to include x86_64 endpoint and checksum for
-Oracle Java 10. The i586 version is not (yet) available. 
+Oracle Java 10. The i586 version is not (yet) available.
 
 ## v2.0.1 - (2018-05-02)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -136,6 +136,20 @@ default['java']['jdk']['8']['x86_64']['checksum'] = '28a00b9400b6913563553e09e80
 default['java']['jdk']['8']['i586']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-linux-i586.tar.gz'
 default['java']['jdk']['8']['i586']['checksum'] = '0a4310d31246924d5c3cd161b9da7f446acef373e6484452c80de8d8519f5a33'
 
+# x86_64
+default['java']['jdk']['10']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/10.0.1+10/fb4372174a714e6b8c52526dc134031e/jdk-10.0.1_linux-x64_bin.tar.gz'
+default['java']['jdk']['10']['x86_64']['checksum'] = 'ae8ed645e6af38432a56a847597ac61d4283b7536688dbab44ab536199d1e5a4'
+
+# i586
+default['java']['jdk']['10']['i586']['url'] = 'NOT YET AVAILABLE'
+default['java']['jdk']['10']['i586']['checksum'] = 'NOT YET AVAILABLE'
+
+default['java']['jdk']['10']['bin_cmds'] = %w(appletviewer jar javac javapackager jconsole jdeprscan jimage jlink jmod
+                                              jshell jstatd orbd rmid serialver unpack200 xjc idlj jarsigner javadoc javaws
+                                              jcontrol jdeps jinfo jmap jps jstack jweblauncher pack200 rmiregistry servertool wsgen
+                                              jaotc java javap jcmd jdb jhsdb jjs jmc jrunscript  jstat keytool rmic schemagen tnameserv
+                                              wsimport)
+
 default['java']['oracle']['jce']['enabled'] = false
 default['java']['oracle']['jce']['8']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
 default['java']['oracle']['jce']['8']['checksum'] = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -151,6 +151,8 @@ default['java']['jdk']['10']['bin_cmds'] = %w(appletviewer jar javac javapackage
                                               wsimport)
 
 default['java']['oracle']['jce']['enabled'] = false
+default['java']['oracle']['jce']['10']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
+default['java']['oracle']['jce']['10']['checksum'] = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'
 default['java']['oracle']['jce']['8']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
 default['java']['oracle']['jce']['8']['checksum'] = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'
 default['java']['oracle']['jce']['7']['url'] = 'http://ORACLE_HAS_REMOVED_THESE_FILES.SELF_HOST_THEM_INSTEAD'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -147,7 +147,7 @@ default['java']['jdk']['10']['i586']['checksum'] = 'NOT YET AVAILABLE'
 default['java']['jdk']['10']['bin_cmds'] = %w(appletviewer jar javac javapackager jconsole jdeprscan jimage jlink jmod
                                               jshell jstatd orbd rmid serialver unpack200 xjc idlj jarsigner javadoc javaws
                                               jcontrol jdeps jinfo jmap jps jstack jweblauncher pack200 rmiregistry servertool wsgen
-                                              jaotc java javap jcmd jdb jhsdb jjs jmc jrunscript  jstat keytool rmic schemagen tnameserv
+                                              jaotc java javap jcmd jdb jhsdb jjs jmc jrunscript jstat keytool rmic schemagen tnameserv
                                               wsimport)
 
 default['java']['oracle']['jce']['enabled'] = false

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -30,21 +30,10 @@ end
 
 java_home = node['java']['java_home']
 arch = node['java']['arch']
-
-case node['java']['jdk_version'].to_s
-when '6'
-  tarball_url = node['java']['jdk']['6'][arch]['url']
-  tarball_checksum = node['java']['jdk']['6'][arch]['checksum']
-  bin_cmds = node['java']['jdk']['6']['bin_cmds']
-when '7'
-  tarball_url = node['java']['jdk']['7'][arch]['url']
-  tarball_checksum = node['java']['jdk']['7'][arch]['checksum']
-  bin_cmds = node['java']['jdk']['7']['bin_cmds']
-when '8'
-  tarball_url = node['java']['jdk']['8'][arch]['url']
-  tarball_checksum = node['java']['jdk']['8'][arch]['checksum']
-  bin_cmds = node['java']['jdk']['8']['bin_cmds']
-end
+version = node['java']['jdk_version'].to_s
+tarball_url = node['java']['jdk'][version][arch]['url']
+tarball_checksum = node['java']['jdk'][version][arch]['checksum']
+bin_cmds = node['java']['jdk'][version]['bin_cmds']
 
 include_recipe 'java::set_java_home'
 


### PR DESCRIPTION
### Description

- Update oracle recipe to not perform a switch on java major version and instead
use the version provided in attributes. This allows end users to include new Java
versions without the cookbook requiring an update each time a major version gets
released
- Updated the oracle_install resource to pick up semantic versioning that Oracle
has started using for Java 10+
- Updated the default attributes file to include x86_64 endpoint and checksum for
Oracle Java 10. The i586 version is not (yet) available.

### Issues Resolved

https://github.com/sous-chefs/java/issues/463
https://github.com/sous-chefs/java/issues/460
https://github.com/sous-chefs/java/issues/453
https://github.com/sous-chefs/java/issues/447

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable

### Comments

The new functionality is not tested as there is no test harness for Oracle Java installation. I assume this is by design and I don't want to change that.

The new functionality has not been documented as there is nothing to document. The new functionality keeps with the current documentation without needing any changes.

Also, I might be stupid and not know how to make an "X" in these checkboxes :) 