### PR TITLE
[ssl_endpoint] affect certout

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,7 +31,7 @@ suites:
       - centos-7
       - ubuntu-14.04
     run_list:
-      - recipe[test_java::openjdk6]
+      - recipe[test::openjdk6]
   - name: openjdk-7
     includes:
       - amazon-linux
@@ -43,7 +43,7 @@ suites:
       - ubuntu-14.04
       - ubuntu-16.04
     run_list:
-      - recipe[test_java::openjdk7]
+      - recipe[test::openjdk7]
   - name: openjdk-8
     includes:
       - amazon-linux
@@ -57,26 +57,26 @@ suites:
       - ubuntu-16.04
       - ubuntu-18.04
     run_list:
-      - recipe[test_java::openjdk8]
+      - recipe[test::openjdk8]
   - name: oracle-8
     run_list:
-      - recipe[test_java::oracle8]
+      - recipe[test::oracle8]
   - name: oracle-direct
     run_list:
-      - recipe[test_java::oracle_direct]
+      - recipe[test::oracle_direct]
     verifier:
       inspec_tests:
         - test/integration/oracle-8
   - name: openjdk-direct
     run_list:
-      - recipe[test_java::openjdk_direct]
+      - recipe[test::openjdk_direct]
   - name: oracle-rpm-8
     includes:
       - centos-6
       - centos-7
       - fedora-27
     run_list:
-      - recipe[test_java::oracle_rpm8]
+      - recipe[test::oracle_rpm8]
     verifier:
       inspec_tests:
         - test/integration/oracle-8

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -112,14 +112,14 @@ action_class do
 
     certendpoint = new_resource.ssl_endpoint
     unless certendpoint.nil?
-      cmd = Mixlib::ShellOut.new("echo QUIT | openssl s_client -showcerts -connect #{certendpoint}")
+      cmd = Mixlib::ShellOut.new("echo QUIT | openssl s_client -showcerts -connect #{certendpoint} 2> /dev/null | openssl x509")
       cmd.run_command
       Chef::Log.debug(cmd.format_for_exception)
 
       Chef::Application.fatal!("Error returned when attempting to retrieve certificate from remote endpoint #{certendpoint}: #{cmd.exitstatus}", cmd.exitstatus) unless cmd.exitstatus == 0
 
-      certout cmd.stdout.split(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----/)
-      return "-----BEGIN CERTIFICATE-----#{certout[1]}-----END CERTIFICATE-----" if certout.size > 2 && !certout[1].empty?
+      certout = cmd.stdout
+      return certout unless certout.empty?
       Chef::Application.fatal!("Unable to parse certificate from openssl query of #{certendpoint}.", 999)
     end
 

--- a/test/fixtures/cookbooks/test/recipes/java_cert.rb
+++ b/test/fixtures/cookbooks/test/recipes/java_cert.rb
@@ -5,3 +5,7 @@ end
 java_certificate 'java_certificate_test' do
   cert_file '/tmp/java_certificate_test.pem'
 end
+
+java_certificate 'java_certificate_ssl_endpoint' do
+  ssl_endpoint 'google.com:443'
+end

--- a/test/fixtures/cookbooks/test/recipes/openjdk6.rb
+++ b/test/fixtures/cookbooks/test/recipes/openjdk6.rb
@@ -1,3 +1,3 @@
-include_recipe 'test_java::base'
+include_recipe 'test::base'
 include_recipe 'java::default'
-include_recipe 'test_java::java_cert'
+include_recipe 'test::java_cert'

--- a/test/fixtures/cookbooks/test/recipes/openjdk7.rb
+++ b/test/fixtures/cookbooks/test/recipes/openjdk7.rb
@@ -1,5 +1,5 @@
 node.default['java']['jdk_version'] = '7'
 
-include_recipe 'test_java::base'
+include_recipe 'test::base'
 include_recipe 'java::default'
-include_recipe 'test_java::java_cert'
+include_recipe 'test::java_cert'

--- a/test/fixtures/cookbooks/test/recipes/openjdk8.rb
+++ b/test/fixtures/cookbooks/test/recipes/openjdk8.rb
@@ -1,5 +1,5 @@
 node.default['java']['jdk_version'] = '8'
 
-include_recipe 'test_java::base'
+include_recipe 'test::base'
 include_recipe 'java::default'
-include_recipe 'test_java::java_cert'
+include_recipe 'test::java_cert'

--- a/test/fixtures/cookbooks/test/recipes/openjdk_direct.rb
+++ b/test/fixtures/cookbooks/test/recipes/openjdk_direct.rb
@@ -1,3 +1,3 @@
-include_recipe 'test_java::base'
+include_recipe 'test::base'
 include_recipe 'java::openjdk'
-include_recipe 'test_java::java_cert'
+include_recipe 'test::java_cert'

--- a/test/fixtures/cookbooks/test/recipes/oracle8.rb
+++ b/test/fixtures/cookbooks/test/recipes/oracle8.rb
@@ -3,6 +3,6 @@ node.default['java']['install_flavor'] = 'oracle'
 node.default['java']['oracle']['accept_oracle_download_terms'] = true
 node.default['java']['oracle']['jce']['enabled'] = true
 
-include_recipe 'test_java::base'
+include_recipe 'test::base'
 include_recipe 'java::default'
-include_recipe 'test_java::java_cert'
+include_recipe 'test::java_cert'

--- a/test/fixtures/cookbooks/test/recipes/oracle_direct.rb
+++ b/test/fixtures/cookbooks/test/recipes/oracle_direct.rb
@@ -1,6 +1,6 @@
 node.default['java']['jdk_version'] = '8'
 node.default['java']['oracle']['accept_oracle_download_terms'] = true
 
-include_recipe 'test_java::base'
+include_recipe 'test::base'
 include_recipe 'java::oracle'
-include_recipe 'test_java::java_cert'
+include_recipe 'test::java_cert'

--- a/test/fixtures/cookbooks/test/recipes/oracle_rpm8.rb
+++ b/test/fixtures/cookbooks/test/recipes/oracle_rpm8.rb
@@ -2,6 +2,6 @@ node.default['java']['jdk_version'] = '8'
 node.default['java']['install_flavor'] = 'oracle_rpm'
 node.default['java']['oracle']['accept_oracle_download_terms'] = true
 
-include_recipe 'test_java::base'
+include_recipe 'test::base'
 include_recipe 'java::default'
-include_recipe 'test_java::java_cert'
+include_recipe 'test::java_cert'


### PR DESCRIPTION
### Description

When we use ssl_endpoint, we have a undefined `certout`. 

```bash
kitchen verify oracle-8-debian-8
...
       Running handlers:
       [2018-07-10T21:01:49+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2018-07-10T21:01:49+00:00] ERROR: Exception handlers complete
       Chef Client failed. 20 resources updated in 57 seconds
       [2018-07-10T21:01:49+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2018-07-10T21:01:49+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2018-07-10T21:01:49+00:00] FATAL: NoMethodError: java_certificate[java_certificate_ssl_endpoint] (test::java_cert line 9) had an error: NoMethodError: undefined method `certout' for #<#<Class:0x00000000043b0318>:0x000000000442c7b0>
```