### PR TITLE
[ssl_endpoint] fix on v2.1.0

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -112,14 +112,14 @@ action_class do
 
     certendpoint = new_resource.ssl_endpoint
     unless certendpoint.nil?
-      cmd = Mixlib::ShellOut.new("echo QUIT | openssl s_client -showcerts -connect #{certendpoint}")
+      cmd = Mixlib::ShellOut.new("echo QUIT | openssl s_client -showcerts -connect #{certendpoint} 2> /dev/null | openssl x509")
       cmd.run_command
       Chef::Log.debug(cmd.format_for_exception)
 
       Chef::Application.fatal!("Error returned when attempting to retrieve certificate from remote endpoint #{certendpoint}: #{cmd.exitstatus}", cmd.exitstatus) unless cmd.exitstatus == 0
 
-      certout cmd.stdout.split(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----/)
-      return "-----BEGIN CERTIFICATE-----#{certout[1]}-----END CERTIFICATE-----" if certout.size > 2 && !certout[1].empty?
+      certout = cmd.stdout
+      return certout unless certout.empty?
       Chef::Application.fatal!("Unable to parse certificate from openssl query of #{certendpoint}.", 999)
     end
 

--- a/test/fixtures/cookbooks/test_java/recipes/java_cert.rb
+++ b/test/fixtures/cookbooks/test_java/recipes/java_cert.rb
@@ -5,3 +5,7 @@ end
 java_certificate 'java_certificate_test' do
   cert_file '/tmp/java_certificate_test.pem'
 end
+
+java_certificate 'java_certificate_ssl_endpoint' do
+  ssl_endpoint 'google.com:443'
+end


### PR DESCRIPTION
### Description

When we use ssl_endpoint, we have a undefined `certout`. 

```bash
kitchen verify oracle-8-debian-8
...
       Running handlers:
       [2018-07-10T21:01:49+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2018-07-10T21:01:49+00:00] ERROR: Exception handlers complete
       Chef Client failed. 20 resources updated in 57 seconds
       [2018-07-10T21:01:49+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2018-07-10T21:01:49+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2018-07-10T21:01:49+00:00] FATAL: NoMethodError: java_certificate[java_certificate_ssl_endpoint] (test::java_cert line 9) had an error: NoMethodError: undefined method `certout' for #<#<Class:0x00000000043b0318>:0x000000000442c7b0>
```