### PR TITLE
Verify artifact after download from Oracle

### DIFF
--- a/resources/oracle_install.rb
+++ b/resources/oracle_install.rb
@@ -265,8 +265,8 @@ action_class do
                                    timeout: new_resource.download_timeout
         )
       end
-      #Can't verify anything with HTTP return codes from Oracle. For example, they return 200 for auth failure.
-      #Do a generic verification of the download
+      # Can't verify anything with HTTP return codes from Oracle. For example, they return 200 for auth failure.
+      # Do a generic verification of the download
       unless oracle_downloaded?(download_path, new_resource)
         Chef::Application.fatal!("Checksum verification failure. Possible wrong checksum or download from Oracle failed.\nVerify artifact checksum and/or verify #{download_path} is an archive and not an HTML response from Oracle")
       end


### PR DESCRIPTION
Do a post download checksum of Oracle artifacts
Can't rely on HTTP codes since they don't use them properly on all
errors

### Description

Using existing verification functions, adds a post-download verification of artifacts downloaded directly from Oracle.

### Issues Resolved

#478 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable