### PR TITLE
Remove deprecated dependencie for Chef 14+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
+## 3.0.0 - (2018-08-02)
+
+- Removed deprecated cookbook dependencies
+- Changed required Chef version to 14+
+
 ## 2.2.0 - (2018-07-19)
 
 - Updated Oracle Java links to 8u181

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ run_list(
 
 ## Requirements
 
-Chef 12.9+
+Chef 14+
 
 ### Platforms
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Recipes and resources for installing Java and managing certificates'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.0'
+version           '3.0.0'
 
 supports 'debian'
 supports 'ubuntu'
@@ -25,9 +25,6 @@ supports 'smartos'
 supports 'mac_os_x'
 supports 'zlinux'
 
-depends 'windows'
-depends 'homebrew'
-
 source_url 'https://github.com/sous-chefs/java'
 issues_url 'https://github.com/sous-chefs/java/issues'
-chef_version '>= 12.9'
+chef_version '>= 14'


### PR DESCRIPTION
Dependencies on the windows and homebrew cookbooks are obsolete since they are now included in Chef. Incremented major version to indicate a breaking change for older versions of Chef.

### Description

Prevents deprecation notices in logs when running chef-client and test-kitchen.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable