### PR TITLE
prevent node access issues when jdk version is a an integer

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -58,7 +58,7 @@ java_alternatives 'set-java-alternatives' do
   java_location jdk.java_home
   default node['java']['set_default']
   priority jdk.alternatives_priority
-  bin_cmds node['java']['jdk'][node['java']['jdk_version']]['bin_cmds']
+  bin_cmds node['java']['jdk'][node['java']['jdk_version'].to_s]['bin_cmds']
   action :set
   only_if { platform_family?('debian', 'rhel', 'fedora', 'amazon') }
 end


### PR DESCRIPTION
Signed-off-by: Ben Abrams <me@benabrams.it>

### Description

when accessing a node object the accessors much be a string (prefered) or a symbol as people may specify a version as an integer cast the value to a string before accessing the dynamic namespace.

### Issues Resolved

fixes #481 
fixes #463 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable