### PR TITLE
add a word boundry when checking cert aliases to prevent substring matching

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -52,7 +52,7 @@ action :install do
     Chef::Log.debug(cmd.format_for_exception)
     Chef::Application.fatal!("Error querying keystore for existing certificate: #{cmd.exitstatus}", cmd.exitstatus) unless cmd.exitstatus == 0
 
-    has_key = !cmd.stdout[/Alias name: #{certalias}/].nil?
+    has_key = !cmd.stdout[/Alias name: \b#{certalias}/].nil?
 
     if has_key
       converge_by("delete existing certificate #{certalias} from #{truststore}") do


### PR DESCRIPTION
### Description

This prevents issues when you have aliases such as `foo` and `foobar`. This is technically a breaking change despite fixing a known issue.

### Issues Resolved

fixes #455 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable