### PR TITLE
Updated Oracle Java links to 8u191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
+## 2.2.2 - (2018-10-17)
+
+- Updated Oracle Java links to 8u191
+
 ## 2.2.1 - (2018-09-29)
 
 - Allows for additional Oracle (post 9) jdk download file naming, including '10.0.2'. '18.9', '11'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,12 +132,12 @@ default['java']['jdk']['8']['bin_cmds'] = %w(appletviewer apt ControlPanel extch
 # Official checksums for the latest release can be found at https://www.oracle.com/webfolder/s/digest/8u172checksum.html
 
 # x86_64
-default['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.tar.gz'
-default['java']['jdk']['8']['x86_64']['checksum'] = '1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3'
+default['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.tar.gz'
+default['java']['jdk']['8']['x86_64']['checksum'] = '53c29507e2405a7ffdbba627e6d64856089b094867479edc5ede4105c1da0d65'
 
 # i586
-default['java']['jdk']['8']['i586']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-i586.tar.gz'
-default['java']['jdk']['8']['i586']['checksum'] = 'd78a023abffb7ce4aade43e6db64bbad5984e7c82c54c332da445c9a79c1a904'
+default['java']['jdk']['8']['i586']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-i586.tar.gz'
+default['java']['jdk']['8']['i586']['checksum'] = '640333e749f24428b78c2b10422f7174f8fbd0b8acde27526c195024fad8b6b6'
 
 # x86_64
 default['java']['jdk']['10']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/10.0.1+10/fb4372174a714e6b8c52526dc134031e/jdk-10.0.1_linux-x64_bin.tar.gz'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Recipes and resources for installing Java and managing certificates'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.2.1'
+version           '2.2.2'
 
 supports 'debian'
 supports 'ubuntu'


### PR DESCRIPTION
### Description

Updated Oracle Java links to 8u191

### Issues Resolved

The current version `jdk-8u191` it's not available anymore.

### Check List
- Tested on oracle-8-ubuntu-160
- Run chefspec tests