### PR TITLE
Allow overwrite `returns` property of windows_packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ See `attributes/default.rb` for default values.
 - `node['java']['windows']['aws_access_key_id']` - AWS Acess Key ID to use with AWS API calls
 - `node['java']['windows']['aws_secret_access_key']` - AWS Secret Access Key to use with AWS API calls
 - `node['java']['windows']['aws_session_token']` - AWS Session Token to use with AWS API calls
+- `node['java']['windows']['returns']` - The allowed return codes for the package to
+  be installed on Windows machines (default is 0, you can define an array of valid values.)
 - `node['java']['ibm']['url']` - The URL which to download the IBM JDK/SDK. See the `ibm` recipe section below.
 - `node['java']['ibm']['accept_ibm_download_terms']` - Indicates that you accept IBM's EULA (for `java::ibm`)
 - `node['java']['oracle_rpm']['type']` - Type of java RPM (`jre` or `jdk`), default `jdk`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,7 @@ when 'windows'
   default['java']['windows']['public_jre_home'] = nil
   default['java']['windows']['owner'] = 'administrator'
   default['java']['windows']['remove_obsolete'] = false
+  default['java']['windows']['returns'] = 0
 when 'mac_os_x'
   default['java']['install_flavor'] = 'homebrew'
 else

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -100,6 +100,7 @@ windows_package node['java']['windows']['package_name'] do
   source cache_file_path
   checksum node['java']['windows']['checksum']
   action :install
+  returns node['java']['windows']['returns']
   installer_type :custom
   options "/s #{additional_options}"
   notifies :write, 'log[jdk-version-changed]', :immediately


### PR DESCRIPTION
Some times are necessary to alter the accepted return code from java installer,
this way i can reuse java cookbook overriding only some attributes.

For now i have to use `edit_resource` as:
```ruby
# Install java.
include_recipe 'java'
# Edit main java resource for accept 1603 return code.
edit_resource!(:windows_package, node['java']['windows']['package_name']) do
  returns [0, 1603]
end
```

with this little modify i'm able to set the attribute more easily.