### PR TITLE
Require Chef 13.4 and remove windows dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ run_list(
 
 ## Requirements
 
-Chef 12.9+
+Chef 13.4+
 
 ### Platforms
 
@@ -80,7 +80,6 @@ Chef 12.9+
 ### Cookbooks
 
 - homebrew
-- windows
 
 ## Attributes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,9 +25,8 @@ supports 'smartos'
 supports 'mac_os_x'
 supports 'zlinux'
 
-depends 'windows'
 depends 'homebrew'
 
 source_url 'https://github.com/sous-chefs/java'
 issues_url 'https://github.com/sous-chefs/java/issues'
-chef_version '>= 12.9'
+chef_version '>= 13.4'

--- a/resources/jce.rb
+++ b/resources/jce.rb
@@ -49,8 +49,6 @@ action :install do
   jre_path = node['java']['install_type'] == 'jdk' ? 'jre' : ''
 
   if node['os'] == 'windows'
-    include_recipe 'windows'
-
     staging_path = ::File.join(jce_home, jdk_version)
     staging_local_policy = ::File.join(staging_path, "UnlimitedJCEPolicyJDK#{jdk_version}", 'local_policy.jar')
     staging_export_policy = ::File.join(staging_path, "UnlimitedJCEPolicyJDK#{jdk_version}", 'US_export_policy.jar')


### PR DESCRIPTION
windows_path is built into Chef 13.4. By requiring a more modern chef
we can remove the dependency on the entire windows cookbook.

Signed-off-by: Tim Smith <tsmith@chef.io>