### PR TITLE
Recipe to install Azul's zulu jdk upto 11

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -172,3 +172,20 @@ default['java']['oracle']['jce']['7']['checksum'] = 'CALCULATE_THIS_FROM_YOUR_FI
 default['java']['oracle']['jce']['6']['url'] = 'http://ORACLE_HAS_REMOVED_THESE_FILES.SELF_HOST_THEM_INSTEAD'
 default['java']['oracle']['jce']['6']['checksum'] = 'CALCULATE_THIS_FROM_YOUR_FILE'
 default['java']['oracle']['jce']['home'] = '/opt/java_jce'
+
+#Azul's zulu jdk installation default attributes
+default['zulu']['java']['windows']['11']['x86_64']['url']='https://cdn.azul.com/zulu/bin/zulu11.2.3-jdk11.0.1-win_x64.msi'
+default['zulu']['java']['windows']['10']['x86_64']['url']='https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-win_x64.msi'
+default['zulu']['java']['windows']['9']['x86_64']['url']='https://cdn.azul.com/zulu/bin/zulu9.0.7.1-jdk9.0.7-win_x64.msi'
+default['zulu']['java']['windows']['8']['x86_64']['url']='https://cdn.azul.com/zulu/bin/zulu8.31.0.1-jdk8.0.181-win_x64.msi'
+
+#Zulu CCK for jdk 11,10 and 9 is not available currently in the official site of zulu once it is available respective url will be updated.
+default['zulu']['cck']['windows']['11']['x86_64']['url']=nil
+default['zulu']['cck']['windows']['10']['x86_64']['url']=nil
+default['zulu']['cck']['windows']['9']['x86_64']['url']=nil
+default['zulu']['cck']['windows']['8']['x86_64']['url']='http://cdn.azul.com/zcck/bin/zcck8.0.0.4-win_x64.msi'
+
+default['zulu']['cck']['linux']['11']['x86_64']['url']=nil
+default['zulu']['cck']['linux']['10']['x86_64']['url']=nil
+default['zulu']['cck']['linux']['9']['x86_64']['url']=nil
+default['zulu']['cck']['linux']['8']['x86_64']['url']='http://cdn.azul.com/zcck/bin/zcck8.0.0.4-linux.x86_64.rpm'

--- a/recipes/zulujdk.rb
+++ b/recipes/zulujdk.rb
@@ -1,8 +1,8 @@
-jdk_version=node[:java][:jdk_version]
+jdk_version=node['java']['jdk_version']
 if platform?('windows')
 
    windows_package 'zulu-Jdk' do
-        node.override[:java][:java_home]="C:\\Program Files\\Zulu\\zulu-#{jdk_version}\\bin"
+        node.override['java']['java_home']="C:\\Program Files\\Zulu\\zulu-#{jdk_version}\\bin"
         case jdk_version
         when '11'
           url=node['zulu']['java']['windows']['11']['x86_64']['url']
@@ -25,6 +25,14 @@ if platform?('windows')
         installer_type :msi
         action :install
         only_if {node['zulu']['cck']['windows'][jdk_version]['x86_64']['url'] != nil }
+   end
+   env 'JAVA_HOME' do
+     value node['java']['java_home']
+   end
+
+  # update path
+   windows_path node['java']['java_home'] do
+    action :add
    end
 
 elsif platform_family?('rhel','oracle')

--- a/recipes/zulujdk.rb
+++ b/recipes/zulujdk.rb
@@ -1,0 +1,46 @@
+jdk_version=node[:java][:jdk_version]
+if platform?('windows')
+
+   windows_package 'zulu-Jdk' do
+        node.override[:java][:java_home]="C:\\Program Files\\Zulu\\zulu-#{jdk_version}\\bin"
+        case jdk_version
+        when '11'
+          url=node['zulu']['java']['windows']['11']['x86_64']['url']
+        when '10'
+          url=node['zulu']['java']['windows']['10']['x86_64']['url']
+        when '9'
+          url=node['zulu']['java']['windows']['9']['x86_64']['url']
+        when '8'
+          url=node['zulu']['java']['windows']['8']['x86_64']['url']
+        else
+           raise 'Unsupported JDK version'
+        end
+        source url
+        installer_type :msi
+        action :install
+   end
+   #Install ZCCK for windows
+   windows_package 'Windows CCK' do
+        source node['zulu']['cck']['windows'][jdk_version]['x86_64']['url']
+        installer_type :msi
+        action :install
+        only_if {node['zulu']['cck']['windows'][jdk_version]['x86_64']['url'] != nil }
+   end
+
+elsif platform_family?('rhel','oracle')
+   yum_repository 'zulu-$releasever - Azul Systems Inc., Zulu packages for $basearch' do
+      name 'zulu'
+      baseurl 'http://repos.azulsystems.com/rhel/$releasever/$basearch'
+      gpgkey 'http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems'
+      action :create
+   end
+   package "zulu-#{jdk_version}"
+   #Install ZCCK for linux
+   rpm_package 'Linux ZCCK' do
+        source node['zulu']['cck']['linux'][jdk_version]['x86_64']['url']
+        action :install
+        only_if {node['zulu']['cck']['linux'][jdk_version]['x86_64']['url'] != nil }
+   end   
+else
+   raise "Unsupported platform"
+end


### PR DESCRIPTION
### Description

This PR adds a recipe zulujdk.rb which is capable of installing the Zulu jdk up to 11 in Linux and windows OS, this also installs the available commercial compatibility kit.