### PR TITLE
Add servername for sni support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the Java cookbook.
 
 - Set java home on macosx using /usr/libexec/java_home
 - Find command should have ./ for path to search, works for nix and mac
+- make java_certificate work with SNI endpoints
 
 ## 3.1.1 - (2018-11-09)
 

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -112,7 +112,7 @@ action_class do
 
     certendpoint = new_resource.ssl_endpoint
     unless certendpoint.nil?
-      cmd = Mixlib::ShellOut.new("echo QUIT | openssl s_client -showcerts -connect #{certendpoint} 2> /dev/null | openssl x509")
+      cmd = Mixlib::ShellOut.new("echo QUIT | openssl s_client -showcerts -servername #{certendpoint.split(':').first} -connect #{certendpoint} 2> /dev/null | openssl x509")
       cmd.run_command
       Chef::Log.debug(cmd.format_for_exception)
 


### PR DESCRIPTION
SNI support is needed for working connections to CDN providers.

### Description

This makes the ssl_endpoint attribute work with CDN providers requiring SNI.
No certificate is provided by the remote endpoint unless a servername is supplied.

https://blog.chrismeller.com/testing-sni-certificates-with-openssl
[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable