### PR TITLE
OpenJDK 11 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,6 +58,16 @@ suites:
       - ubuntu-18.04
     run_list:
       - recipe[test::openjdk8]
+  - name: openjdk-11
+    includes:
+      - centos-7
+      - ubuntu-16.04
+      - ubuntu-18.04
+    run_list:
+      - recipe[test::openjdk11]
+    verifier:
+      inspec_tests:
+        - test/integration/openjdk-11
   - name: oracle-8
     run_list:
       - recipe[test::oracle8]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
+## Unreleased
+
+- Add support OpenJDK 11
+
 ## 3.1.2 - (2018-12-11)
 
 - Set java home on macosx using /usr/libexec/java_home

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -61,7 +61,8 @@ module ChefCookbook
       when 'debian'
         format('java-%s-openjdk%s/jre', @jdk_version, arch_dir)
       when 'rhel', 'fedora', 'amazon'
-        format('jre-1.%s.0-openjdk%s', @jdk_version, arch_dir)
+        path = @node['java']['jdk_version'].to_i < 11 ? 'jre-1.%s.0-openjdk%s' : 'java-%s'
+        format(path, @jdk_version, arch_dir)
       else
         'jre'
       end

--- a/recipes/set_attributes_from_version.rb
+++ b/recipes/set_attributes_from_version.rb
@@ -25,9 +25,9 @@ when 'rhel', 'fedora', 'amazon'
                                       when 'oracle_rpm'
                                         '/usr/java/latest'
                                       else
-                                        "/usr/lib/jvm/java-1.#{node['java']['jdk_version']}.0"
+                                        node['java']['jdk_version'].to_i < 11 ? "/usr/lib/jvm/java-1.#{node['java']['jdk_version']}.0" : "/usr/lib/jvm/java-#{node['java']['jdk_version']}"
                                       end
-  node.default['java']['openjdk_packages'] = ["java-1.#{node['java']['jdk_version']}.0-openjdk", "java-1.#{node['java']['jdk_version']}.0-openjdk-devel"]
+  node.default['java']['openjdk_packages'] = node['java']['jdk_version'].to_i < 11 ? ["java-1.#{node['java']['jdk_version']}.0-openjdk", "java-1.#{node['java']['jdk_version']}.0-openjdk-devel"] : ["java-#{node['java']['jdk_version']}-openjdk", "java-#{node['java']['jdk_version']}-openjdk-devel"]
 when 'suse'
   node.default['java']['java_home'] = case node['java']['install_flavor']
                                       when 'oracle'

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 
 property :java_home, String, default: lazy { node['java']['java_home'] }
-property :keystore_path, String, default: lazy { "#{node['java']['java_home']}/jre/lib/security/cacerts" }
+property :keystore_path, String, default: lazy { node['java']['jdk_version'].to_i < 11 ? "#{node['java']['java_home']}/jre/lib/security/cacerts" : "#{node['java']['java_home']}/lib/security/cacerts" }
 property :keystore_passwd, String, default: 'changeit'
 property :cert_alias, String, name_property: true
 property :cert_data, String

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -180,4 +180,24 @@ describe ChefCookbook::OpenJDK do
       expect(subject.java_location).to eq(expected_path)
     end
   end
+
+  context 'centos 7.6.1804 64 bit' do
+    before do
+      node['platform'] = 'centos'
+      node['platform_version'] = '7.6.1804'
+      node['platform_family'] = 'rhel'
+      node['kernel']['machine'] = 'x86_64'
+    end
+
+    it 'sets the java location for JDK 6' do
+      expected_path = '/usr/lib/jvm/jre-1.6.0-openjdk.x86_64/bin/java'
+      expect(subject.java_location).to eq(expected_path)
+    end
+
+    it 'sets the java location for JDK 11' do
+      node['java']['jdk_version'] = '11'
+      expected_path = '/usr/lib/jvm/java-11/bin/java'
+      expect(subject.java_location).to eq(expected_path)
+    end
+  end
 end

--- a/spec/set_attributes_from_version_spec.rb
+++ b/spec/set_attributes_from_version_spec.rb
@@ -7,6 +7,11 @@ describe 'java::set_attributes_from_version' do
       'jdk_version' => '6',
       'packages' => ['java-1.6.0-openjdk', 'java-1.6.0-openjdk-devel'],
     },
+    'centos-7.6.1804' => {
+      'java_home' => '/usr/lib/jvm/java-1.6.0',
+      'jdk_version' => '6',
+      'packages' => ['java-1.6.0-openjdk', 'java-1.6.0-openjdk-devel'],
+    },
     'redhat-6.9' => {
       'java_home' => '/usr/lib/jvm/java-1.6.0',
       'jdk_version' => '6',

--- a/test/fixtures/cookbooks/test/recipes/openjdk11.rb
+++ b/test/fixtures/cookbooks/test/recipes/openjdk11.rb
@@ -1,0 +1,5 @@
+node.default['java']['jdk_version'] = '11'
+
+include_recipe 'test::base'
+include_recipe 'java::default'
+include_recipe 'test::java_cert'

--- a/test/integration/openjdk-11/verify_openjdk-11.rb
+++ b/test/integration/openjdk-11/verify_openjdk-11.rb
@@ -1,0 +1,11 @@
+# the right version of java is installed
+describe command('java -version 2>&1') do
+  its('stdout') { should match /11\.0\.1/ }
+end
+
+unless os.bsd?
+  # alternatives were properly set
+  describe command('update-alternatives --display jar') do
+    its('stdout') { should match %r{\/usr\/lib\/jvm\/java-11} } # https://rubular.com/r/H7J6J3q9GhJJ5A
+  end
+end


### PR DESCRIPTION
Signed-off-by: Eric Millbrandt <emillbrandt@brightcove.com>

### Description

Installs OpenJDK on:
- CentOS7
- Ubuntu 16.04
- Ubuntu 18.04

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.