### PR TITLE
Remove support for EOL Java 6 / 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ default['java']['jdk']['7']['x86_64']['checksum'] = 'The SHA-256 checksum of the
 default['java']['oracle']['accept_oracle_download_terms'] = true
 ```
 
-NOTE: Oracle JDK 6 & 7 are unable to be automatically downloaded at this time.
-
 ## Usage
 
 Include the `java` recipe wherever you would like Java installed, such as a run list (`recipe[java]`) or a cookbook (`include_recipe 'java'`). By default, OpenJDK 6 is installed. The `install_flavor` attribute is used to determine which JDK to install (AdoptOpenJDK, OpenJDK, Oracle, IBM, or Windows), and `jdk_version` specifies which version to install (currently 6 and 7 are supported for all JDK types, 8 and 10 for Oracle and AdoptOpenJDK ).
@@ -67,7 +65,7 @@ run_list(
 
 ## Requirements
 
-Chef 12.9+
+Chef 13+
 
 ### Platforms
 
@@ -94,8 +92,6 @@ See `attributes/default.rb` for default values.
 - `node['java']['java_home']` - Default location of the "`$JAVA_HOME`". To configure this attribute for `ibm`, `ibm_tar`, and `oracle_rpm` install flavors, you must use an attribute precedence of `force_default` or higher in your attribute file.
 - `node['java']['set_etc_environment']` - Optionally sets JAVA_HOME in `/etc/environment` for Default `false`.
 - `node['java']['openjdk_packages']` - Array of OpenJDK package names to install in the `java::openjdk` recipe. This is set based on the platform.
-- `node['java']['tarball']` - Name of the tarball to retrieve from your internal repository, default `jdk1.6.0_29_i386.tar.gz`
-- `node['java']['tarball_checksum']` - Checksum for the tarball, if you use a different tarball, you also need to create a new sha256 checksum
 - `node['java']['jdk']` - Version and architecture specific attributes for setting the URL on Oracle's site for the JDK, and the checksum of the .tar.gz.
 - `node['java']['oracle']['accept_oracle_download_terms']` - Indicates that you accept Oracle's EULA
 - `node['java']['windows']['url']` - The internal location of your java install for windows
@@ -148,7 +144,7 @@ On platforms such as SmartOS that require the acceptance of a license agreement 
 
 This recipe installs the `oracle` flavor of Java. This recipe does not use distribution packages as Oracle changed the licensing terms with JDK 1.6u27 and prohibited the practice for both RHEL and Debian family platforms.
 
-As of 26 March 2012 you can no longer directly download the JDK from Oracle's website without using a special cookie. This cookbook uses that cookie to download the oracle recipe on your behalf, however the `java::oracle` recipe forces you to set either override the `node['java']['oracle']['accept_oracle_download_terms']` to true or set up a private repository accessible by HTTP.
+You can not directly download the JDK from Oracle's website without using a special cookie. This cookbook uses that cookie to download the oracle recipe on your behalf, however the `java::oracle` recipe forces you to set either override the `node['java']['oracle']['accept_oracle_download_terms']` to true or set up a private repository accessible by HTTP.
 
 override the `accept_oracle_download_terms` in, e.g., `roles/base.rb`
 
@@ -455,4 +451,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,40 +87,6 @@ default['java']['oracle']['accept_oracle_download_terms'] = false
 
 # direct download paths for oracle, you have been warned!
 
-# jdk6 attributes
-default['java']['jdk']['6']['bin_cmds'] = %w(appletviewer apt ControlPanel extcheck HtmlConverter idlj jar jarsigner
-                                             java javac javadoc javah javap javaws jconsole jcontrol jdb jhat
-                                             jinfo jmap jps jrunscript jsadebugd jstack jstat jstatd jvisualvm
-                                             keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry
-                                             schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
-
-# x86_64
-default['java']['jdk']['6']['x86_64']['url'] = 'http://download.oracle.com/otn/java/jdk/6u45-b06/jdk-6u45-linux-x64.bin'
-default['java']['jdk']['6']['x86_64']['checksum'] = '6b493aeab16c940cae9e3d07ad2a5c5684fb49cf06c5d44c400c7993db0d12e8'
-
-# i586
-default['java']['jdk']['6']['i586']['url'] = 'http://download.oracle.com/otn/java/jdk/6u45-b06/jdk-6u45-linux-i586.bin'
-default['java']['jdk']['6']['i586']['checksum'] = 'd53b5a2518d80e1d95565f0adda54eee229dc5f4a1d1a3c2f7bf5045b168a357'
-
-# jdk7 attributes
-
-default['java']['jdk']['7']['bin_cmds'] = %w(appletviewer apt ControlPanel extcheck idlj jar jarsigner java javac
-                                             javadoc javafxpackager javah javap javaws jcmd jconsole jcontrol jdb
-                                             jhat jinfo jmap jps jrunscript jsadebugd jstack jstat jstatd jvisualvm
-                                             keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry
-                                             schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
-
-# Oracle doesn't seem to publish SHA256 checksums for Java releases, so we use MD5 instead.
-# Official checksums for the latest release can be found at https://www.oracle.com/webfolder/s/digest/7u75checksum.html
-
-# x86_64
-default['java']['jdk']['7']['x86_64']['url'] = 'http://download.oracle.com/otn/java/jdk/7u75-b13/jdk-7u75-linux-x64.tar.gz'
-default['java']['jdk']['7']['x86_64']['checksum'] = '6f1f81030a34f7a9c987f8b68a24d139'
-
-# i586
-default['java']['jdk']['7']['i586']['url'] = 'http://download.oracle.com/otn/java/jdk/7u75-b13/jdk-7u75-linux-i586.tar.gz'
-default['java']['jdk']['7']['i586']['checksum'] = 'e4371a4fddc049eca3bfef293d812b8e'
-
 # jdk8 attributes
 
 default['java']['jdk']['8']['bin_cmds'] = %w(appletviewer apt ControlPanel extcheck idlj jar jarsigner java javac

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,25 +33,6 @@ module ChefCookbook
       File.join(java_home_parent(@java_home), openjdk_path, 'bin/java')
     end
 
-    def alternatives_priority
-      if @jdk_version == '6'
-        # 'accepted' default for java 6
-        1061
-      elsif @jdk_version == '7'
-        # i just made this number up
-        1100
-      elsif @jdk_version.to_i > 7
-        # just a guard against the incoming java 8
-        # so this cookbook will actually work for.. new versions of java
-        1110
-      else
-        # it's not 6, it's not 7, it's not newer than
-        # 7, but we probably want to install it, so
-        # override 6's priority. arbitrary number.
-        1062
-      end
-    end
-
     def java_home_parent(java_home)
       Pathname.new(java_home).parent.to_s
     end

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -57,7 +57,7 @@ end
 java_alternatives 'set-java-alternatives' do
   java_location jdk.java_home
   default node['java']['set_default']
-  priority jdk.alternatives_priority
+  priority 1100
   bin_cmds node['java']['jdk'][node['java']['jdk_version'].to_s]['bin_cmds']
   action :set
   only_if { platform_family?('debian', 'rhel', 'fedora', 'amazon') }

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -38,7 +38,7 @@ action :install do
                end
   truststore_passwd = new_resource.keystore_passwd
   certalias = new_resource.cert_alias
-  certdata = new_resource.cert_data ? new_resource.cert_data : fetch_certdata
+  certdata = new_resource.cert_data || fetch_certdata
 
   hash = OpenSSL::Digest::SHA512.hexdigest(certdata)
   certfile = "#{Chef::Config[:file_cache_path]}/#{certalias}.cert.#{hash}"

--- a/resources/oracle_install.rb
+++ b/resources/oracle_install.rb
@@ -260,7 +260,7 @@ action_class do
         shell_out!(
           %(curl --fail --create-dirs -L --retry #{new_resource.retries} --retry-delay #{new_resource.retry_delay} --cookie "#{cookie}" #{new_resource.url} -o #{download_path} --connect-timeout #{new_resource.connect_timeout} #{proxy} ),
                                    timeout: new_resource.download_timeout
-        )
+                                 )
       end
       # Can't verify anything with HTTP return codes from Oracle. For example, they return 200 for auth failure.
       # Do a generic verification of the download


### PR DESCRIPTION
These are long ago EOL. This removes the attributes and helper method.

Signed-off-by: Tim Smith <tsmith@chef.io>