### PR TITLE
clarify ubuntu 14.04 support in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file is used to list changes made in each version of the Java cookbook.
 - Updated AdoptOpenJDK links for Java 11 to 11.0.1
 - Remove support for Java 6 & 7
 - Remove platform suport for untested platforms (smartOS, XenServer, zlinux, arch)
-- Remove Ubuntu 14.04 support
+- Remove testing of Ubuntu 14.04, support at this point is no longer guaranteed and patches or other changes may not be accepted going further as Ubuntu 14.04 will be shortly EOL
 - Fixed oracle download link for JDK 8 (update to 8u202 from 8u201)
 - fixed specs for windows
 


### PR DESCRIPTION
Signed-off-by: Ben Abrams <me@benabrams.it>

### Description

Clarifies that we did not intentionally break Ubuntu 14.04 support and merely removed testing and making it clear that any support going forward is what it is. New patches may be considered at the discretion of the reviewer/maintainer but should not have any expectations going forward in terms of support.

We discussed this in slack. If the verbiage needs to be further behind I am more than happy to work through it but currently it gives a false sense of that if someone is on Ubuntu 14.04 they can't use what's currently in master. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable