### PR TITLE
Make Homebrew Cask into an attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Make Homebrew Cask name an attribute to allow for other options (ex: adoptopenjdk)
+
 ## 4.1.0 - 2019-05-08
 
 - Added new install flavor "corretto" for Amazon's Corretto distribution of OpenJDK

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ when 'windows'
   default['java']['windows']['returns'] = 0
 when 'mac_os_x'
   default['java']['install_flavor'] = 'homebrew'
+  default['java']['homebrew']['cask'] = 'java'
 else
   default['java']['install_flavor'] = 'openjdk'
 end

--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -3,6 +3,6 @@ include_recipe 'homebrew::cask'
 include_recipe 'java::notify'
 
 homebrew_tap 'caskroom/versions'
-homebrew_cask "java#{node['java']['jdk_version']}" do
+homebrew_cask "#{node['java']['homebrew']['cask']}#{node['java']['jdk_version']}" do
   notifies :write, 'log[jdk-version-changed]', :immediately
 end


### PR DESCRIPTION
### Description

Makes the Cask name into an attribute so can opt for different java install (`java` vs. `adoptopenjdk`) ... solves the problem where `java` went behind Oracle login wall and inches towards to using AdoptOpenJDK.

### Issues Resolved

https://github.com/sous-chefs/java/issues/544

### Check List

MacOS machine ... so that has some annoying nuances.

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable