### PR TITLE
Fix for issue 538 to paramaterize file_cache_path references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+## 4.2.0 - 2019-06-20
+
+- Fix for issue 538
+- Added "download_path" node attribute defaulting to file_cache_path
+- Replaced all hardcoded instances of file_cache_path with the node attribute 
+
 ## 4.1.0 - 2019-05-08
 
 - Added new install flavor "corretto" for Amazon's Corretto distribution of OpenJDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file is used to list changes made in each version of the Java cookbook.
 
 - Fix for issue 538
 - Added "download_path" node attribute defaulting to file_cache_path
-- Replaced all hardcoded instances of file_cache_path with the node attribute 
+- Replaced all hardcoded instances of file_cache_path with the node attribute
 
 ## 4.1.0 - 2019-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is used to list changes made in each version of the Java cookbook.
 
 - Upgrade circleci orb to version 2 and add yamllint and markdown lint
 
-## 4.2.0 - 2019-06-20
+## 4.2.0 - 2019-07-15
 
 - Fix for issue 538
 - Added "download_path" node attribute defaulting to file_cache_path

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Chef 13.4+
 
 See `attributes/default.rb` for default values.
 
-- `node['java']['download_path']` - Location to download and extract the tarball 
+- `node['java']['download_path']` - Location to download and extract the tarball
 - `node['java']['install_flavor']` - Flavor of JVM you would like installed (`oracle`, `oracle_rpm`, `openjdk`, `adoptopenjdk`, `ibm`, `windows`), default `openjdk` on Linux/Unix platforms, `windows` on Windows platforms.
 - `node['java']['install_type']` - Type of Java installation, defauls to jdk, needed for JCE to find the install path of jar's for JDK/JRE installation.
 - `node['java']['jdk_version']` - JDK version to install, defaults to `'6'`.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Chef 13.4+
 
 See `attributes/default.rb` for default values.
 
+- `node['java']['download_path']` - Location to download and extract the tarball 
 - `node['java']['install_flavor']` - Flavor of JVM you would like installed (`oracle`, `oracle_rpm`, `openjdk`, `adoptopenjdk`, `ibm`, `windows`), default `openjdk` on Linux/Unix platforms, `windows` on Windows platforms.
 - `node['java']['install_type']` - Type of Java installation, defauls to jdk, needed for JCE to find the install path of jar's for JDK/JRE installation.
 - `node['java']['jdk_version']` - JDK version to install, defaults to `'6'`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 # default jdk attributes
+default['java']['download_path'] = Chef::Config[:file_cache_path]
 default['java']['jdk_version'] = '8'
 default['java']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? 'x86_64' : 'i586'
 default['java']['openjdk_packages'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Recipes and resources for installing Java and managing certificates'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.1.0'
+version           '4.2.0'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/ibm.rb
+++ b/recipes/ibm.rb
@@ -38,12 +38,12 @@ package 'rpm' do
   only_if { platform_family?('debian') && jdk_filename !~ /archive/ }
 end
 
-template "#{Chef::Config[:file_cache_path]}/installer.properties" do
+template "#{node['java']['download_path']}/installer.properties" do
   source 'ibm_jdk.installer.properties.erb'
   only_if { node['java']['ibm']['accept_ibm_download_terms'] }
 end
 
-remote_file "#{Chef::Config[:file_cache_path]}/#{jdk_filename}" do
+remote_file "#{node['java']['download_path']}/#{jdk_filename}" do
   source source_url
   mode '0755'
   if node['java']['ibm']['checksum']
@@ -70,7 +70,7 @@ java_alternatives 'set-java-alternatives' do
 end
 
 execute 'install-ibm-java' do
-  cwd Chef::Config[:file_cache_path]
+  cwd node['java']['download_path']
   environment('_JAVA_OPTIONS' => '-Dlax.debug.level=3 -Dlax.debug.all=true',
               'LAX_DEBUG' => '1')
   command "./#{jdk_filename} -f ./installer.properties -i silent"

--- a/recipes/ibm_tar.rb
+++ b/recipes/ibm_tar.rb
@@ -35,7 +35,7 @@ unless jdk_filename =~ /\.(tar.gz|tgz)$/
   raise "The attribute `node['java']['ibm']['url']` must specify a .tar.gz file"
 end
 
-remote_file "#{Chef::Config[:file_cache_path]}/#{jdk_filename}" do
+remote_file "#{node['java']['download_path']}/#{jdk_filename}" do
   source source_url
   mode '0755'
   if node['java']['ibm']['checksum']
@@ -69,7 +69,7 @@ java_alternatives 'set-java-alternatives' do
 end
 
 execute 'untar-ibm-java' do
-  cwd Chef::Config[:file_cache_path]
+  cwd node['java']['download_path']
   command "tar xzf ./#{jdk_filename} -C #{node['java']['java_home']} --strip 1"
   notifies :set, 'java_alternatives[set-java-alternatives]', :immediately
   notifies :write, 'log[jdk-version-changed]', :immediately

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -33,7 +33,7 @@ s3_bucket = node['java']['windows']['bucket']
 s3_remote_path = node['java']['windows']['remote_path']
 
 uri = ::URI.parse(node['java']['windows']['url'])
-cache_file_path = File.join(Chef::Config[:file_cache_path], File.basename(::URI.unescape(uri.path)))
+cache_file_path = File.join(node['java']['download_path'], File.basename(::URI.unescape(uri.path)))
 
 if s3_bucket && s3_remote_path
   aws_s3_file cache_file_path do

--- a/resources/adoptopenjdk_install.rb
+++ b/resources/adoptopenjdk_install.rb
@@ -41,12 +41,12 @@ action :install do
   end.run_action(:create)
 
   unless ::File.exist?(app_dir)
-    download_path = "#{Chef::Config[:file_cache_path]}/#{tarball_name}"
+    download_path = "#{node['java']['download_path']}/#{tarball_name}"
     if adoptopendjk_downloaded?(download_path, new_resource)
       Chef::Log.debug('AdoptOpenJDK tarball already downloaded, not downloading again')
     else
       Chef::Log.debug("downloading tarball from #{URI.parse(new_resource.url).host}")
-      remote_file "#{Chef::Config[:file_cache_path]}/#{tarball_name}" do
+      remote_file "#{node['java']['download_path']}/#{tarball_name}" do
         source new_resource.url
         checksum new_resource.checksum
         retries new_resource.retries
@@ -62,17 +62,17 @@ action :install do
         action :nothing
       end.run_action(:install)
 
-      cmd = shell_out(%(tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{Chef::Config[:file_cache_path]}" --no-same-owner)
+      cmd = shell_out(%(tar xvzf "#{node['java']['download_path']}/#{tarball_name}" -C "#{node['java']['download_path']}" --no-same-owner)
                      )
       unless cmd.exitstatus == 0
         Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
       end
 
       cmd = shell_out(
-        %(mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" )
+        %(mv "#{node['java']['download_path']}/#{app_dir_name}" "#{app_dir}" )
       )
       unless cmd.exitstatus == 0
-        Chef::Application.fatal!(%( Command \' mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" \' failed ))
+        Chef::Application.fatal!(%( Command \' mv "#{node['java']['download_path']}/#{app_dir_name}" "#{app_dir}" \' failed ))
       end
 
       # change ownership of extracted files

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -41,7 +41,7 @@ action :install do
   certdata = new_resource.cert_data || fetch_certdata
 
   hash = OpenSSL::Digest::SHA512.hexdigest(certdata)
-  certfile = "#{Chef::Config[:file_cache_path]}/#{certalias}.cert.#{hash}"
+  certfile = "#{node['java']['download_path']}/#{certalias}.cert.#{hash}"
   cmd = Mixlib::ShellOut.new("#{keytool} -list -keystore #{truststore} -storepass #{truststore_passwd} -rfc -alias \"#{certalias}\"")
   cmd.run_command
   keystore_cert = cmd.stdout.match(/^[-]+BEGIN.*END(\s|\w)+[-]+$/m).to_s
@@ -111,7 +111,7 @@ action :remove do
     end
   end
 
-  FileUtils.rm_f("#{Chef::Config[:file_cache_path]}/#{certalias}.cert.*")
+  FileUtils.rm_f("#{node['java']['download_path']}/#{certalias}.cert.*")
 end
 
 action_class do

--- a/resources/jce.rb
+++ b/resources/jce.rb
@@ -36,7 +36,7 @@ action :install do
     recursive true
   end
 
-  r = remote_file "#{Chef::Config[:file_cache_path]}/jce.zip" do
+  r = remote_file "#{node['java']['download_path']}/jce.zip" do
     source jce_url
     checksum jce_checksum
     headers(
@@ -87,7 +87,7 @@ action :install do
         find ./ -name '*.jar' | xargs -I JCE_JAR mv JCE_JAR #{jce_home}/#{jdk_version}/
         chmod -R 0644 #{jce_home}/#{jdk_version}/*.jar
       EOF
-      cwd Chef::Config[:file_cache_path]
+      cwd node['java']['download_path']
       creates ::File.join(jce_home, jdk_version, 'US_export_policy.jar')
     end
 

--- a/resources/oracle_install.rb
+++ b/resources/oracle_install.rb
@@ -64,7 +64,7 @@ action :install do
 
   unless ::File.exist?(app_dir)
     if new_resource.url =~ /oracle\.com.*$/
-      download_path = "#{Chef::Config[:file_cache_path]}/#{tarball_name}"
+      download_path = "#{node['java']['download_path']}/#{tarball_name}"
       if oracle_downloaded?(download_path, new_resource)
         Chef::Log.debug('oracle tarball already downloaded, not downloading again')
       else
@@ -73,7 +73,7 @@ action :install do
       end
     else
       Chef::Log.debug('downloading tarball from an unofficial repository')
-      remote_file "#{Chef::Config[:file_cache_path]}/#{tarball_name}" do
+      remote_file "#{node['java']['download_path']}/#{tarball_name}" do
         source new_resource.url
         checksum new_resource.checksum
         retries new_resource.retries
@@ -87,7 +87,7 @@ action :install do
       case tarball_name
       when /^.*\.bin/
         cmd = shell_out(
-          %(cd "#{Chef::Config[:file_cache_path]}";
+          %(cd "#{node['java']['download_path']}";
               bash ./#{tarball_name} -noregister
             )
         )
@@ -96,7 +96,7 @@ action :install do
         end
       when /^.*\.zip/
         cmd = shell_out(
-          %(unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{Chef::Config[:file_cache_path]}" )
+          %(unzip "#{node['java']['download_path']}/#{tarball_name}" -d "#{node['java']['download_path']}" )
         )
         unless cmd.exitstatus == 0
           Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
@@ -108,7 +108,7 @@ action :install do
         end.run_action(:install)
 
         cmd = shell_out(
-          %(tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{Chef::Config[:file_cache_path]}" --no-same-owner)
+          %(tar xvzf "#{node['java']['download_path']}/#{tarball_name}" -C "#{node['java']['download_path']}" --no-same-owner)
         )
         unless cmd.exitstatus == 0
           Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
@@ -116,10 +116,10 @@ action :install do
       end
 
       cmd = shell_out(
-        %(mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" )
+        %(mv "#{node['java']['download_path']}/#{app_dir_name}" "#{app_dir}" )
       )
       unless cmd.exitstatus == 0
-        Chef::Application.fatal!(%( Command \' mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" \' failed ))
+        Chef::Application.fatal!(%( Command \' mv "#{node['java']['download_path']}/#{app_dir_name}" "#{app_dir}" \' failed ))
       end
 
       # change ownership of extracted files
@@ -246,7 +246,7 @@ action_class do
   end
 
   def download_direct_from_oracle(tarball_name, new_resource)
-    download_path = "#{Chef::Config[:file_cache_path]}/#{tarball_name}"
+    download_path = "#{node['java']['download_path']}/#{tarball_name}"
     cookie = 'oraclelicense=accept-securebackup-cookie'
     proxy = "-x #{new_resource.proxy}" unless new_resource.proxy.nil?
     if new_resource.accept_oracle_download_terms


### PR DESCRIPTION
### Description

This change creates a node attribute default['java']['download_path'] which defaults to Chef::Config[:file_cache_path].  All references to Chef::Config[:file_cache_path] have been replaced by node['java']['download_path'] which allows wrappers to set the value of the download and extract path of the tarball to a location other than Chef::Config[:file_cache_path].  These references were not replaced in spec files.  

### Issues Resolved

This is a resolution to issue 538. The path to download and extract the tarball was hardcoded to  Chef::Config[:file_cache_path] which caused failures at my organization due to a 500 mb partition sizing for /var/chef across the organization.  

### Check List
Note:  All tests did not pass on the master branch prior to modifying the code, so similar tests failed when running the same tests after code modifications.  

- [ ?] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ x] New functionality includes testing.
- [ x] New functionality has been documented in the README if applicable