### PR TITLE
Update Amazon Corretto to 8.222.10.1 and 11.0.4.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Upgrade Amazon Corretto to the latest versions: 8.222.10.1 and 11.0.4.11.1
 - Upgrade circleci orb to version 2 and add yamllint and markdown lint
 
 ## 4.2.0 - 2019-07-15

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -176,10 +176,10 @@ default['java']['adoptopenjdk']['12']['x86_64']['openj9-large-heap']['checksum']
 default['java']['adoptopenjdk']['12']['bin_cmds']['default'] = %w(jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
 
 # Amazon Corretto
-default['java']['corretto']['8']['x86_64']['url'] = 'https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-linux-x64.tar.gz'
-default['java']['corretto']['8']['x86_64']['checksum'] = '782d5452cd7395340d791dbdd0f418a8'
+default['java']['corretto']['8']['x86_64']['url'] = 'https://d3pxv6yz143wms.cloudfront.net/8.222.10.1/amazon-corretto-8.222.10.1-linux-x64.tar.gz'
+default['java']['corretto']['8']['x86_64']['checksum'] = '6599a081ce56dda81ee7ac23802d6e67'
 default['java']['corretto']['8']['bin_cmds'] = %w(appletviewer clhsdb extcheck hsdb idlj jar jarsigner java java-rmi.cgi javac javadoc javafxpackager javah javap javapackager jcmd jconsole jdb jdeps jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
 
-default['java']['corretto']['11']['x86_64']['url'] = 'https://d3pxv6yz143wms.cloudfront.net/11.0.3.7.1/amazon-corretto-11.0.3.7.1-linux-x64.tar.gz'
-default['java']['corretto']['11']['x86_64']['checksum'] = '08a0cea184824c5477a62ce6a6a0fb0b'
+default['java']['corretto']['11']['x86_64']['url'] = 'https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz'
+default['java']['corretto']['11']['x86_64']['checksum'] = '4bbcd5e6d721fef56e46b3bfa8631c1c'
 default['java']['corretto']['11']['bin_cmds'] = %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)


### PR DESCRIPTION
### Description

Updates to the latest corretto builds provided by amazon: 
https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html
https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable