### PR TITLE
Fixed java_certificate regex where it checks if cert exists in cacert file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
+- Fixed java_certificate pattern match for if cert exists.
 
 ## 4.3.0 (2019-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
-- Fixed java_certificate pattern match for if cert exists.
+- Fixed java_certificate regex where it checks if cert exists in cacert file.
 
 ## 4.3.0 (2019-08-04)
 

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -56,7 +56,7 @@ action :install do
     Chef::Log.debug(cmd.format_for_exception)
     Chef::Application.fatal!("Error querying keystore for existing certificate: #{cmd.exitstatus}", cmd.exitstatus) unless cmd.exitstatus == 0
 
-    has_key = !cmd.stdout[/Alias name: \b#{certalias}/i].nil?
+    has_key = !cmd.stdout[/Alias name: \b#{certalias}\s*$/i].nil?
 
     if has_key
       converge_by("delete existing certificate #{certalias} from #{truststore}") do


### PR DESCRIPTION
### Description

In testing openjdk 11 with this java cookbook I found that the regex used to determine if a cacert is installed and should be deleted before being re-added incorrectly matches similarly named cacerts. Cert comapanyenterpriserootca2 is matching another cert called comapanyenterpriserootca2.1 see https://rubular.com/r/ITi0qdT26D6RWg for broken example.  The certificate resource then attempts to delete comapanyenterpriserootca2 which doesn't exist and fails with fatal error "Error deleting existing certificate comapanyenterpriserootca2".  See https://rubular.com/r/iF81EPJjw7d8Sv for the proposed fixed example"


### Issues Resolved



### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable