### PR TITLE
Update readme with default openjdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ default['java']['oracle']['accept_oracle_download_terms'] = true
 
 ## Usage
 
-Include the `java` recipe wherever you would like Java installed, such as a run list (`recipe[java]`) or a cookbook (`include_recipe 'java'`). By default, OpenJDK 6 is installed. The `install_flavor` attribute is used to determine which JDK to install (AdoptOpenJDK, OpenJDK, Oracle, IBM, or Windows), and `jdk_version` specifies which version to install (currently 6 and 7 are supported for all JDK types, 8 and 10 for Oracle and AdoptOpenJDK ).
+Include the `java` recipe wherever you would like Java installed, such as a run list (`recipe[java]`) or a cookbook (`include_recipe 'java'`). By default, OpenJDK 8 is installed. The `install_flavor` attribute is used to determine which JDK to install (AdoptOpenJDK, OpenJDK, Oracle, IBM, or Windows), and `jdk_version` specifies which version to install (currently 6 and 7 are supported for all JDK types, 8 and 10 for Oracle and AdoptOpenJDK ).
 
 ### Examples
 


### PR DESCRIPTION
### Description

The readme states that the default openjdk version that gets installed is 6, but when I run the default recipe without changing any attributes version 8 gets installed.

```
         * apt_package[openjdk-8-jdk, openjdk-8-jre-headless] action install
           - install version 8u232-b09-0ubuntu1 of package openjdk-8-jdk
           - install version 8u232-b09-0ubuntu1 of package openjdk-8-jre-headless
```

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable