### PR TITLE
[598] JAVA_HOME on Linux (AdoptOpenJDK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Fix JAVA_HOME for `adoptopenjdk_linux_install` resource
+
 ## 8.1.0 (2020-04-19)
 
 - Added `openjdk_pkg_install` resource

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,15 +2,12 @@
 driver:
   name: dokken
   privileged: true  # because Docker and SystemD/Upstart
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  env: [CHEF_LICENSE=accept]
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
-  deprecations_as_errors: false
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -66,10 +66,7 @@ suites:
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
       inputs: {java_version: '7'}
-    includes:
-      - amazon-linux # Used for dokken kitchen support
-      - amazonlinux-2
-      - centos-7
+    includes: ["amazon-linux", "amazonlinux-2", "centos-7"]
 
   - name: openjdk-pkg-8
     run_list:
@@ -78,8 +75,7 @@ suites:
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
       inputs: {java_version: '8'}
-    excludes:
-      - debian-10
+    excludes: ["debian-10"]
 
   - name: openjdk-pkg-11
     run_list:
@@ -88,9 +84,7 @@ suites:
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
       inputs: {java_version: '11'}
-    excludes:
-      - amazon-linux
-      - debian-9
+    excludes: ["amazon-linux", "debian-9"]
 
   - name: openjdk-pkg-14
     run_list:
@@ -99,8 +93,7 @@ suites:
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
       inputs: {java_version: '14'}
-    includes:
-      - ubuntu-20.04
+    includes: [ubuntu-20.04]
 
   # AdoptOpenJDK
   # Version 8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,11 +1,11 @@
 ---
 driver:
   name: vagrant
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  env: [CHEF_LICENSE=accept]
 
 provisioner:
   name: chef_zero
-  deprecations_as_errors: false
-  # log_level: :info
 
 verifier:
   name: inspec

--- a/libraries/adopt_openjdk_helpers.rb
+++ b/libraries/adopt_openjdk_helpers.rb
@@ -4,7 +4,6 @@ module Java
       def sub_dir(url)
         uri = URI.parse(url)
         f = uri.path.split('/')[-2]
-        puts f
 
         case f
         when /jdk8/

--- a/resources/adoptopenjdk_linux_install.rb
+++ b/resources/adoptopenjdk_linux_install.rb
@@ -85,6 +85,11 @@ action :install do
   end
 
   node.default['java']['java_home'] = new_resource.java_home
+
+  append_if_no_line 'Java Home' do
+    path '/etc/profile.d/jdk.sh'
+    line "export JAVA_HOME=#{new_resource.java_home}"
+  end
 end
 
 action :remove do

--- a/resources/adoptopenjdk_linux_install.rb
+++ b/resources/adoptopenjdk_linux_install.rb
@@ -87,7 +87,7 @@ action :install do
   node.default['java']['java_home'] = new_resource.java_home
 
   append_if_no_line 'Java Home' do
-    path '/etc/profile.d/jdk.sh'
+    path '/etc/profile.d/java.sh'
     line "export JAVA_HOME=#{new_resource.java_home}"
   end
 end

--- a/test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb
+++ b/test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb
@@ -66,12 +66,14 @@ control 'check-certificate' do
   end
 end
 
-control 'JAVA_HOME' do
-  impact 0.1
-  title 'Verify the JAVA_HOME is set correctly'
-  desc 'Verify that JAVA_HOME is set correctly and to the correct version in the bash profile'
+if os.darwin?
+  control 'JAVA_HOME' do
+    impact 0.1
+    title 'Verify the JAVA_HOME is set correctly'
+    desc 'Verify that JAVA_HOME is set correctly and to the correct version in the bash profile'
 
-  describe file('/etc/profile') do
-    its('content') { should match /JAVA_HOME/ }
+    describe file('/etc/profile') do
+      its('content') { should match /JAVA_HOME/ }
+    end
   end
 end

--- a/test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb
+++ b/test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb
@@ -66,14 +66,12 @@ control 'check-certificate' do
   end
 end
 
-if os.darwin?
-  control 'JAVA_HOME' do
-    impact 0.1
-    title 'Verify the JAVA_HOME is set correctly'
-    desc 'Verify that JAVA_HOME is set correctly and to the correct version in the bash profile'
+control 'JAVA_HOME' do
+  impact 0.1
+  title 'Verify the JAVA_HOME is set correctly'
+  desc 'Verify that JAVA_HOME is set correctly and to the correct version in the bash profile'
 
-    describe file('/etc/profile') do
-      its('content') { should match /JAVA_HOME/ }
-    end
+  describe file('/etc/profile') do
+    its('content') { should match /JAVA_HOME/ }
   end
 end


### PR DESCRIPTION
### Description

Attempts to fix the JAVA_HOME on Linux for AdoptOpenJDK

This does not contain an extra test for the variable as it doesn't get set correctly in Dokken/Docker.

I can confirm that adding a test in for vagrant, this does actually work. 

### Issues Resolved

Partly #598 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable