### PR TITLE
Add openjdk_source_install resource and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+## 8.1.2 (2020-04-20)
+
+- Add OpenJDK source install resource
+- Add documentation for openjdk_source_install
+- Default the openjdk_install resource to install using the package manager by default
+
 ## 8.1.1 (2020-04-19)
 
 - Fix JAVA_HOME for `adoptopenjdk_linux_install` resource

--- a/documentation/resources/openjdk_install.md
+++ b/documentation/resources/openjdk_install.md
@@ -11,19 +11,22 @@ Introduced: v8.0.0
 
 ## Properties
 
-| Name                  | Type            | Default                             | Description                                         |
-| --------------------- | --------------- | ----------------------------------- | --------------------------------------------------- |
-| version               | String          |                                     | Java version to install                             |
-| url                   | String          | `default_openjdk_url(version)`      | The URL to download from                            |
-| checksum              | String          | `default_openjdk_checksum(version)` | The checksum for the downloaded file                |
-| java_home             | String          | Based on the version                | Set to override the java_home                       |
-| java_home_mode        | Integer, String | `0755`                              | The permission for the Java home directory          |
-| java_home_owner       | String          | `root`                              | Owner of the Java Home                              |
-| java_home_group       | String          | `node['root_group']`                | Group for the Java Home                             |
-| default               | Boolean         | `true`                              | Whether to set this as the defalut Java             |
-| bin_cmds              | Array           | `default_openjdk_bin_cmds(version)` | A list of bin_cmds based on the version and variant |
-| alternatives_priority | Integer         | `1`                                 | Alternatives priority to set for this Java          |
-| reset_alternatives    | Boolean         | `true`                              | Whether to reset alternatives before setting        |
+| Name                  | Type            | Default | Description                                         | Allowed values     |
+| --------------------- | --------------- | ------- | --------------------------------------------------- | ------------------ |
+| version               | String          |         | Java version to install                             |
+| url                   | String          |         | The URL to download from                            |
+| checksum              | String          |         | The checksum for the downloaded file                |
+| java_home             | String          |         | Set to override the java_home                       |
+| java_home_mode        | Integer, String |         | The permission for the Java home directory          |
+| java_home_owner       | String          |         | Owner of the Java Home                              |
+| java_home_group       | String          |         | Group for the Java Home                             |
+| default               | Boolean         |         | Whether to set this as the defalut Java             |
+| bin_cmds              | Array           |         | A list of bin_cmds based on the version and variant |
+| alternatives_priority | Integer         |         | Alternatives priority to set for this Java          |
+| reset_alternatives    | Boolean         |         | Whether to reset alternatives before setting        |
+| pkg_names             | Array           |         | List of packages to install                         |
+| pkg_version           | String          |         | Package version to install                          |
+| install_type          | String          |         | Installation type                                   | `package` `source` |
 
 ## Examples
 

--- a/documentation/resources/openjdk_pkg_install.md
+++ b/documentation/resources/openjdk_pkg_install.md
@@ -11,16 +11,16 @@ Introduced: v8.1.0
 
 ## Properties
 
-| Name                  | Type            | Default                              | Description                                         |
-| --------------------- | --------------- | ------------------------------------ | --------------------------------------------------- |
-| version               | String          |                                      | Java major version to install                       |
-| pkg_names             | Array           | `default_openjdk_pkg_names(version)` | List of packages to install                         |
-| pkg_version           | String          | `nil`                                | Package version to install                          |
-| java_home             | String          | Based on the version                 | Set to override the java_home                       |
-| default               | Boolean         | `true`                               | Whether to set this as the defalut Java             |
-| bin_cmds              | Array           | `default_openjdk_bin_cmds(version)`  | A list of bin_cmds based on the version and variant |
-| alternatives_priority | Integer         | `1062`                                  | Alternatives priority to set for this Java          |
-| reset_alternatives    | Boolean         | `true`                               | Whether to reset alternatives before setting        |
+| Name                  | Type    | Default                              | Description                                         |
+| --------------------- | ------- | ------------------------------------ | --------------------------------------------------- |
+| version               | String  |                                      | Java major version to install                       |
+| pkg_names             | Array   | `default_openjdk_pkg_names(version)` | List of packages to install                         |
+| pkg_version           | String  | `nil`                                | Package version to install                          |
+| java_home             | String  | Based on the version                 | Set to override the java_home                       |
+| default               | Boolean | `true`                               | Whether to set this as the defalut Java             |
+| bin_cmds              | Array   | `default_openjdk_bin_cmds(version)`  | A list of bin_cmds based on the version and variant |
+| alternatives_priority | Integer | `1062`                               | Alternatives priority to set for this Java          |
+| reset_alternatives    | Boolean | `true`                               | Whether to reset alternatives before setting        |
 
 ## Examples
 

--- a/documentation/resources/openjdk_source_install.md
+++ b/documentation/resources/openjdk_source_install.md
@@ -1,0 +1,42 @@
+[back to resource list](https://github.com/sous-chefs/java#resources)
+
+# openjdk_install
+
+Introduced: v8.0.0
+
+## Actions
+
+- `:install`
+- `:remove`
+
+## Properties
+
+| Name                  | Type            | Default                             | Description                                         |
+| --------------------- | --------------- | ----------------------------------- | --------------------------------------------------- |
+| version               | String          |                                     | Java version to install                             |
+| url                   | String          | `default_openjdk_url(version)`      | The URL to download from                            |
+| checksum              | String          | `default_openjdk_checksum(version)` | The checksum for the downloaded file                |
+| java_home             | String          | Based on the version                | Set to override the java_home                       |
+| java_home_mode        | Integer, String | `0755`                              | The permission for the Java home directory          |
+| java_home_owner       | String          | `root`                              | Owner of the Java Home                              |
+| java_home_group       | String          | `node['root_group']`                | Group for the Java Home                             |
+| default               | Boolean         | `true`                              | Whether to set this as the defalut Java             |
+| bin_cmds              | Array           | `default_openjdk_bin_cmds(version)` | A list of bin_cmds based on the version and variant |
+| alternatives_priority | Integer         | `1`                                 | Alternatives priority to set for this Java          |
+| reset_alternatives    | Boolean         | `true`                              | Whether to reset alternatives before setting        |
+
+## Examples
+
+To install OpenJDK 11 and set it as the default Java
+
+```ruby
+openjdk_install '11'
+```
+
+To install OpenJDK 11 and set it as second highest priority
+
+```ruby
+openjdk_install '11' do
+  alternatives_priority 2
+end
+```

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Recipes and resources for installing Java and managing certificates'
-version           '8.1.1'
+version           '8.1.2'
 
 supports 'debian'
 supports 'ubuntu'

--- a/resources/adoptopenjdk_linux_install.rb
+++ b/resources/adoptopenjdk_linux_install.rb
@@ -3,39 +3,49 @@ include Java::Cookbook::AdoptOpenJdkHelpers
 property :version, String, name_property: true, description: 'Java version to install'
 
 property :variant, String,
-         equal_to: %w(hotspot openj9 openj9-large-heap),
-         default: 'openj9',
-         description: 'Install flavour'
+  equal_to: %w(hotspot openj9 openj9-large-heap),
+  default: 'openj9',
+  description: 'Install flavour'
+
 property :url, String,
-         default: lazy { default_adopt_openjdk_url(version)[variant] },
-         description: 'The URL to download from'
+  default: lazy { default_adopt_openjdk_url(version)[variant] },
+  description: 'The URL to download from'
+
 property :checksum, String,
-         regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
-         default: lazy { default_adopt_openjdk_checksum(version)[variant] },
-         description: 'The checksum for the downloaded file'
+  regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
+  default: lazy { default_adopt_openjdk_checksum(version)[variant] },
+  description: 'The checksum for the downloaded file'
+
 property :java_home, String,
-         default: lazy { "/usr/lib/jvm/java-#{version}-adoptopenjdk-#{variant}/#{sub_dir(url)}" },
-         description: 'Set to override the java_home'
+  default: lazy { "/usr/lib/jvm/java-#{version}-adoptopenjdk-#{variant}/#{sub_dir(url)}" },
+  description: 'Set to override the java_home'
+
 property :java_home_mode, String,
-         description: 'The permission for the Java home directory'
+  description: 'The permission for the Java home directory'
+
 property :java_home_owner, String,
-         default: 'root',
-         description: 'Owner of the Java Home'
+  default: 'root',
+  description: 'Owner of the Java Home'
+
 property :java_home_group, String,
-         default: lazy { node['root_group'] },
-         description: 'Group for the Java Home'
+  default: lazy { node['root_group'] },
+  description: 'Group for the Java Home'
+
 property :default, [true, false],
-         default: true,
-         description: ' Whether to set this as the defalut Java'
+  default: true,
+  description: ' Whether to set this as the defalut Java'
+
 property :bin_cmds, Array,
-         default: lazy { default_adopt_openjdk_bin_cmds(version)[variant] },
-         description: 'A list of bin_cmds based on the version and variant'
+  default: lazy { default_adopt_openjdk_bin_cmds(version)[variant] },
+  description: 'A list of bin_cmds based on the version and variant'
+
 property :alternatives_priority, Integer,
-         default: 1,
-         description: 'Alternatives priority to set for this Java'
+  default: 1,
+  description: 'Alternatives priority to set for this Java'
+
 property :reset_alternatives, [true, false],
-         default: true,
-         description: 'Whether to reset alternatives before setting'
+  default: true,
+  description: 'Whether to reset alternatives before setting'
 
 action :install do
   extract_dir = new_resource.java_home.split('/')[0..-2].join('/')

--- a/resources/adoptopenjdk_macos_install.rb
+++ b/resources/adoptopenjdk_macos_install.rb
@@ -1,27 +1,41 @@
 resource_name :adoptopenjdk_macos_install
 include Java::Cookbook::AdoptOpenJdkMacOsHelpers
 
-property :tap_full, [true, false], default: true, description: 'Perform a full clone on the tap, as opposed to a shallow clone'
-property :tap_url, String, description: 'The URL of the tap'
-property :cask_options, String, description: 'Options to pass to the brew command during installation'
-property :homebrew_path, String, description: 'The path to the homebrew binary'
-property :owner, [String, Integer], description: 'The owner of the Homebrew installation'
-property :java_home, String, default: lazy { macos_java_home(version) }, description: 'MacOS specific JAVA_HOME'
+property :tap_full, [true, false],
+  default: true,
+  description: 'Perform a full clone on the tap, as opposed to a shallow clone'
+
+property :tap_url, String,
+  description: 'The URL of the tap'
+
+property :cask_options, String,
+  description: 'Options to pass to the brew command during installation'
+
+property :homebrew_path, String,
+  description: 'The path to the homebrew binary'
+
+property :owner, [String, Integer],
+  description: 'The owner of the Homebrew installation'
+
+property :java_home, String,
+  default: lazy { macos_java_home(version) },
+  description: 'MacOS specific JAVA_HOME'
+
 property :version, String,
-         default: 'adoptopenjdk14',
-         equal_to: %w(
-           adoptopenjdk8 adoptopenjdk8-openj9 adoptopenjdk8-openj9-large
-           adoptopenjdk8-jre adoptopenjdk8-openj9-jre adoptopenjdk8-jre-large
-           adoptopenjdk9 adoptopenjdk10
-           adoptopenjdk11 adoptopenjdk11-openj9 adoptopenjdk11-openj9-large
-           adoptopenjdk11-jre adoptopenjdk11-openj9-jre adoptopenjdk11-openj9-jre-large
-           adoptopenjdk12 adoptopenjdk12-openj9 adoptopenjdk12-openj9-large
-           adoptopenjdk12-jre adoptopenjdk12-openj9-jre adoptopenjdk12-openj9-jre-large
-           adoptopenjdk13 adoptopenjdk13-openj9 adoptopenjdk13-openj9-large
-           adoptopenjdk13-jre adoptopenjdk13-openj9-jre adoptopenjdk13-openj9-jre-large
-           adoptopenjdk14 adoptopenjdk14-openj9 adoptopenjdk14-openj9-large
-           adoptopenjdk14-jre adoptopenjdk14-openj9-jre adoptopenjdk14-openj9-jre-large
-         )
+  default: 'adoptopenjdk14',
+  equal_to: %w(
+    adoptopenjdk8 adoptopenjdk8-openj9 adoptopenjdk8-openj9-large
+    adoptopenjdk8-jre adoptopenjdk8-openj9-jre adoptopenjdk8-jre-large
+    adoptopenjdk9 adoptopenjdk10
+    adoptopenjdk11 adoptopenjdk11-openj9 adoptopenjdk11-openj9-large
+    adoptopenjdk11-jre adoptopenjdk11-openj9-jre adoptopenjdk11-openj9-jre-large
+    adoptopenjdk12 adoptopenjdk12-openj9 adoptopenjdk12-openj9-large
+    adoptopenjdk12-jre adoptopenjdk12-openj9-jre adoptopenjdk12-openj9-jre-large
+    adoptopenjdk13 adoptopenjdk13-openj9 adoptopenjdk13-openj9-large
+    adoptopenjdk13-jre adoptopenjdk13-openj9-jre adoptopenjdk13-openj9-jre-large
+    adoptopenjdk14 adoptopenjdk14-openj9 adoptopenjdk14-openj9-large
+    adoptopenjdk14-jre adoptopenjdk14-openj9-jre adoptopenjdk14-openj9-jre-large
+  )
 
 action :install do
   homebrew_tap 'AdoptOpenJDK/openjdk' do

--- a/resources/alternatives.rb
+++ b/resources/alternatives.rb
@@ -16,14 +16,21 @@
 
 property :java_location, String,
   description: 'Java installation location'
+
 property :bin_cmds, Array,
   description: 'Array of Java tool names to set or unset alternatives on'
-property :default, [true, false], default: true,
-                                  description: 'Whether to set the Java tools as system default. Boolean, defaults to `true`'
-property :priority, Integer, default: 1061,
-                             description: ' Priority of the alternatives. Integer, defaults to `1061`'
-property :reset_alternatives, [true, false], default: true,
-                                             description: 'Whether to reset alternatives before setting them'
+
+property :default, [true, false],
+  default: true,
+  description: 'Whether to set the Java tools as system default. Boolean, defaults to `true`'
+
+property :priority, Integer,
+  default: 1061,
+  description: ' Priority of the alternatives. Integer, defaults to `1061`'
+
+property :reset_alternatives, [true, false],
+  default: true,
+  description: 'Whether to reset alternatives before setting them'
 
 action :set do
   if new_resource.bin_cmds

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -17,15 +17,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+property :cert_alias, String,
+  name_property: true,
+  description: 'The alias of the certificate in the keystore. This defaults to the name of the resource'
 
-property :java_home, String, default: lazy { node['java']['java_home'] }, description: 'The java home directory'
-property :java_version, String, default: lazy { node['java']['jdk_version'] }, description: ' The java version'
-property :keystore_path, String, description: 'Path to the keystore'
-property :keystore_passwd, String, default: 'changeit', description: 'Password to the keystore'
-property :cert_alias, String, name_property: true, description: 'The alias of the certificate in the keystore. This defaults to the name of the resource'
-property :cert_data, String, description: 'The certificate data to install'
-property :cert_file, String, description: 'Path to a certificate file to install'
-property :ssl_endpoint, String, description: 'An SSL end-point from which to download the certificate'
+property :java_home, String,
+  default: lazy { node['java']['java_home'] },
+  description: 'The java home directory'
+
+property :java_version, String,
+  default: lazy { node['java']['jdk_version'] },
+  description: ' The java version'
+
+property :keystore_path, String,
+  description: 'Path to the keystore'
+
+property :keystore_passwd, String,
+  default: 'changeit',
+  description: 'Password to the keystore'
+
+property :cert_data, String,
+  description: 'The certificate data to install'
+
+property :cert_file, String,
+  description: 'Path to a certificate file to install'
+
+property :ssl_endpoint, String,
+  description: 'An SSL end-point from which to download the certificate'
 
 action :install do
   require 'openssl'

--- a/resources/openjdk_install.rb
+++ b/resources/openjdk_install.rb
@@ -2,79 +2,75 @@ resource_name :openjdk_install
 include Java::Cookbook::OpenJdkHelpers
 default_action :install
 
-property :version, String, name_property: true,
-                           description: 'Java version to install'
-property :url, String, default: lazy { default_openjdk_url(version) },
-                       description: 'The URL to download from'
-property :checksum, String, regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/, default: lazy { default_openjdk_checksum(version) },
-                            description: 'The checksum for the downloaded file'
-property :java_home, String, default: lazy { "/usr/lib/jvm/java-#{version}-openjdk/jdk-#{version}" },
-                             description: 'Set to override the java_home'
-property :java_home_mode, String, default: '0755',
-                                  description: 'The permission for the Java home directory'
-property :java_home_owner, String, default: 'root',
-                                   description: 'Owner of the Java Home'
-property :java_home_group, String, default: lazy { node['root_group'] },
-                                   description: 'Group for the Java Home'
-property :default, [true, false], default: true,
-                                  description: ' Whether to set this as the defalut Java'
-property :bin_cmds, Array, default: lazy { default_openjdk_bin_cmds(version) },
-                           description: 'A list of bin_cmds based on the version and variant'
-property :alternatives_priority, Integer, default: 1,
-                                          description: 'Alternatives priority to set for this Java'
-property :reset_alternatives, [true, false], default: true,
-                                             description: 'Whether to reset alternatives before setting'
+property :version, String, name_property: true, description: 'Java major version to install'
+property :install_type, String, default: 'package', equal_to: %w( package source ), description: 'Installation type'
+property :pkg_names, [String, Array], description: 'List of packages to install'
+property :pkg_version, String, description: 'Package version to install'
+property :java_home, String, description: 'Set to override the java_home'
+property :default, [true, false], description: ' Whether to set this as the defalut Java'
+property :bin_cmds, Array, description: 'A list of bin_cmds based on the version and variant'
+property :alternatives_priority, Integer, description: 'Alternatives priority to set for this Java'
+property :reset_alternatives, [true, false], description: 'Whether to reset alternatives before setting'
+property :url, String, description: 'The URL to download from'
+property :checksum, String, description: 'The checksum for the downloaded file'
+property :java_home_mode, String,  description: 'The permission for the Java home directory'
+property :java_home_owner, String, description: 'Owner of the Java Home'
+property :java_home_group, String, description: 'Group for the Java Home'
 
 action :install do
-  extract_dir = new_resource.java_home.split('/')[0..-2].join('/')
-  parent_dir = new_resource.java_home.split('/')[0..-3].join('/')
-  tarball_name = new_resource.url.split('/').last
-
-  directory parent_dir do
-    owner new_resource.java_home_owner
-    group new_resource.java_home_group
-    mode new_resource.java_home_mode
-    recursive true
-  end
-
-  remote_file "#{Chef::Config[:file_cache_path]}/#{tarball_name}" do
-    source new_resource.url
-    checksum new_resource.checksum
-    retries new_resource.retries
-    retry_delay new_resource.retry_delay
-    mode '644'
-  end
-
-  archive_file "#{Chef::Config[:file_cache_path]}/#{tarball_name}" do
-    destination extract_dir
-  end
-
-  node.default['java']['java_home'] = new_resource.java_home
-
-  java_alternatives 'set-java-alternatives' do
-    java_location new_resource.java_home
-    bin_cmds new_resource.bin_cmds
-    priority new_resource.alternatives_priority
-    default new_resource.default
-    reset_alternatives new_resource.reset_alternatives
-    action :set
+  if install_type == 'package'
+    openjdk_pkg_install new_resource.version do
+      pkg_names new_resource.pkg_names
+      pkg_version new_resource.pkg_version
+      java_home new_resource.java_home
+      default new_resource.default
+      bin_cmds new_resource.bin_cmds
+      alternatives_priority new_resource.alternatives_priority
+      reset_alternatives new_resource.reset_alternatives
+    end
+  elsif install_type == 'source'
+    openjdk_source_install new_resource.version do
+      url new_resource.url
+      checksum new_resource.checksum
+      java_home new_resource.java_home
+      java_home_mode new_resource.java_home_mode
+      java_home_group new_resource.java_home_group
+      default new_resource.default
+      bin_cmds new_resource.bin_cmds
+      alternatives_priority new_resource.alternatives_priority
+      reset_alternatives new_resource.reset_alternatives
+    end
+  else
+    ChefLog.fatal('Invalid install method specified')
   end
 end
 
 action :remove do
-  extract_dir = new_resource.java_home.split('/')[0..-2].join('/')
-
-  java_alternatives 'unset-java-alternatives' do
-    java_location new_resource.java_home
-    bin_cmds new_resource.bin_cmds
-    only_if { ::File.exist?(extract_dir) }
-    action :unset
-  end
-
-  directory "Removing #{extract_dir}" do
-    path extract_dir
-    recursive true
-    only_if { ::File.exist?(extract_dir) }
-    action :delete
+  if install_type == 'package'
+    openjdk_pkg_install new_resource.version do
+      pkg_names new_resource.pkg_names
+      pkg_version new_resource.pkg_version
+      java_home new_resource.java_home
+      default new_resource.default
+      bin_cmds new_resource.bin_cmds
+      alternatives_priority new_resource.alternatives_priority
+      reset_alternatives new_resource.reset_alternatives
+      action :remove
+    end
+  elsif install_type == 'source'
+    openjdk_source_install new_resource.version do
+      url new_resource.url
+      checksum new_resource.checksum
+      java_home new_resource.java_home
+      java_home_mode new_resource.java_home_mode
+      java_home_group new_resource.java_home_group
+      default new_resource.default
+      bin_cmds new_resource.bin_cmds
+      alternatives_priority new_resource.alternatives_priority
+      reset_alternatives new_resource.reset_alternatives
+      action :remove
+    end
+  else
+    ChefLog.fatal('Invalid install method specified')
   end
 end

--- a/resources/openjdk_pkg_install.rb
+++ b/resources/openjdk_pkg_install.rb
@@ -3,35 +3,35 @@ include Java::Cookbook::OpenJdkHelpers
 default_action :install
 
 property :version, String,
-         name_property: true,
-         description: 'Java major version to install'
+  name_property: true,
+  description: 'Java major version to install'
 
 property :pkg_names, [String, Array],
-         default: lazy { default_openjdk_pkg_names(version) },
-         description: 'List of packages to install'
+  default: lazy { default_openjdk_pkg_names(version) },
+  description: 'List of packages to install'
 
 property :pkg_version, String,
-         description: 'Package version to install'
+  description: 'Package version to install'
 
 property :java_home, String,
-         default: lazy { default_openjdk_pkg_java_home(version) },
-         description: 'Set to override the java_home'
+  default: lazy { default_openjdk_pkg_java_home(version) },
+  description: 'Set to override the java_home'
 
 property :default, [true, false],
-         default: true,
-         description: ' Whether to set this as the defalut Java'
+  default: true,
+  description: ' Whether to set this as the defalut Java'
 
 property :bin_cmds, Array,
-         default: lazy { default_openjdk_bin_cmds(version) },
-         description: 'A list of bin_cmds based on the version and variant'
+  default: lazy { default_openjdk_bin_cmds(version) },
+  description: 'A list of bin_cmds based on the version and variant'
 
 property :alternatives_priority, Integer,
-         default: 1062,
-         description: 'Alternatives priority to set for this Java'
+  default: 1062,
+  description: 'Alternatives priority to set for this Java'
 
 property :reset_alternatives, [true, false],
-         default: true,
-         description: 'Whether to reset alternatives before setting'
+  default: true,
+  description: 'Whether to reset alternatives before setting'
 
 action :install do
   if platform?('ubuntu')


### PR DESCRIPTION
### Description

Indent all the resources and their options by 2 spaces.
This makes it more readable and take up way less screen space.
Plus it doesn't take so long to organise, so we're more likely to do it.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable