### PR TITLE
Fix typo (I think...)

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -2,7 +2,7 @@
 Chef::Log.fatal("
 
 java::openjdk recipe is now deprecated
-Using the adoptopenjdk_install resource is now recommended
+Using the openjdk_install resource is now recommended
 See: https://github.com/sous-chefs/java/blob/master/documentation/resources/openjdk_install.md for help
 
 ")


### PR DESCRIPTION
Documentation links to `openjdk_install` but error says `adoptopenjdk_install` - I think this typo was introduced in this very large PR:
https://github.com/sous-chefs/java/pull/591/files

### Description

Clearing up confusion for users.

### Issues Resolved

I don't think there are any... 🙏 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable