### PR TITLE
[GH-617] - fix broken :remove action on java_certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Fixed java_certificate resource :remove bugs preventing removal
+
 ## 8.1.2 (2020-04-20)
 
 - Add OpenJDK source install resource

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -118,7 +118,8 @@ action :remove do
   cmd = Mixlib::ShellOut.new("#{keytool} -list -keystore #{truststore} -storepass #{truststore_passwd} -v | grep \"#{certalias}\"")
   cmd.run_command
   has_key = !cmd.stdout[/Alias name: #{certalias}/].nil?
-  Chef::Application.fatal!("Error querying keystore for existing certificate: #{cmd.exitstatus}", cmd.exitstatus) unless cmd.exitstatus == 0
+  does_not_exist = cmd.stdout[/Alias <#{certalias}> does not exist/].nil?
+  Chef::Application.fatal!("Error querying keystore for existing certificate: #{cmd.exitstatus}", cmd.exitstatus) unless (cmd.exitstatus == 0) || does_not_exist
 
   if has_key
     converge_by("remove certificate #{certalias} from #{truststore}") do
@@ -131,7 +132,7 @@ action :remove do
     end
   end
 
-  FileUtils.rm_f("#{new_reource.download_path}/#{certalias}.cert.*")
+  FileUtils.rm_f("#{Chef::Config[:file_cache_path]}/#{certalias}.cert.*")
 end
 
 action_class do

--- a/test/fixtures/cookbooks/test/recipes/java_cert.rb
+++ b/test/fixtures/cookbooks/test/recipes/java_cert.rb
@@ -9,3 +9,7 @@ end
 java_certificate 'java_certificate_ssl_endpoint' do
   ssl_endpoint 'google.com:443'
 end
+
+java_certificate 'java_certificate_ssl_endpoint' do
+  action :remove
+end


### PR DESCRIPTION
Signed-off-by: Joshua Colson <joshua.colson@gmail.com>

### Description

Fix for broken `:remove` action in `java_certificate` resource

### Issues Resolved

#617 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable