### PR TITLE
Restore Chef Infra Client < 16 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
+## UNRELEASED
+
+- Restore compatibility with Chef Infra Client < 16
+- Update Fedora releases in the Kitchen configs
+
 ## 8.2.1 (2020-06-02)
 
 - resolved cookstyle error: resources/adoptopenjdk_install.rb:1:1 warning: `ChefDeprecations/ResourceUsesOnlyResourceName`

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -47,7 +47,7 @@ platforms:
       image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: fedora-30
+  - name: fedora-31
     driver:
       image: dokken/fedora-31
       pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,8 +18,8 @@ platforms:
   - name: debian-10
   - name: freebsd-11
   - name: freebsd-12
-  - name: fedora-30
   - name: fedora-31
+  - name: fedora-32
   - name: opensuse-leap-15
   - name: ubuntu-18.04
   - name: ubuntu-20.04

--- a/resources/adoptopenjdk_install.rb
+++ b/resources/adoptopenjdk_install.rb
@@ -1,4 +1,6 @@
+resource_name :adoptopenjdk_install
 provides :adoptopenjdk_install
+
 default_action :install
 
 # Common options

--- a/resources/adoptopenjdk_linux_install.rb
+++ b/resources/adoptopenjdk_linux_install.rb
@@ -1,4 +1,6 @@
+resource_name :adoptopenjdk_linux_install
 provides :adoptopenjdk_linux_install
+
 include Java::Cookbook::AdoptOpenJdkHelpers
 property :version, String, name_property: true, description: 'Java version to install'
 

--- a/resources/adoptopenjdk_macos_install.rb
+++ b/resources/adoptopenjdk_macos_install.rb
@@ -1,4 +1,6 @@
+resource_name :adoptopenjdk_macos_install
 provides :adoptopenjdk_macos_install
+
 include Java::Cookbook::AdoptOpenJdkMacOsHelpers
 
 property :tap_full, [true, false],

--- a/resources/alternatives.rb
+++ b/resources/alternatives.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: java
-# Provider:: alternatives
+# Resource:: alternatives
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/corretto_install.rb
+++ b/resources/corretto_install.rb
@@ -1,4 +1,6 @@
+resource_name :corretto_install
 provides :corretto_install
+
 include Java::Cookbook::CorrettoHelpers
 
 property :version, String, name_property: true, description: 'Java version to install'

--- a/resources/jce.rb
+++ b/resources/jce.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: java
-# Provider:: jce
+# Resource:: jce
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/openjdk_install.rb
+++ b/resources/openjdk_install.rb
@@ -1,4 +1,6 @@
+resource_name :openjdk_install
 provides :openjdk_install
+
 include Java::Cookbook::OpenJdkHelpers
 default_action :install
 

--- a/resources/openjdk_pkg_install.rb
+++ b/resources/openjdk_pkg_install.rb
@@ -1,4 +1,6 @@
+resource_name :openjdk_pkg_install
 provides :openjdk_pkg_install
+
 include Java::Cookbook::OpenJdkHelpers
 default_action :install
 

--- a/resources/openjdk_source_install.rb
+++ b/resources/openjdk_source_install.rb
@@ -1,4 +1,6 @@
+resource_name :openjdk_install
 provides :openjdk_install
+
 include Java::Cookbook::OpenJdkHelpers
 default_action :install
 


### PR DESCRIPTION
Chef Infra Client 16 needs provides and Chef Infra Client < 16 needs resource_name here. If we support both then we need both.

Signed-off-by: Tim Smith <tsmith@chef.io>