### PR TITLE
Add aarch64 systems for corretto installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
+## Unrleased
+
+- Add aarch64 installation candidate for Corretto
+
 ## 8.3.1 (2020-08-06)
 
 - Extract correct JAVA_HOME from custom URLs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
-## Unrleased
+## Unreleased
 
 - Add aarch64 installation candidate for Corretto
 

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -1,12 +1,11 @@
 module Java
   module Cookbook
     module CorrettoHelpers
-      def correto_arch
+      def corretto_arch
         node['kernel']['machine'].match?('aarch64') ? 'aarch64' : 'x64'
       end
 
       def default_corretto_url(version)
-        corretto_arch = corretto_arch
         if version.to_s == '8'
           "https://corretto.aws/downloads/latest/amazon-corretto-8-#{corretto_arch}-linux-jdk.tar.gz"
         elsif version.to_s == '11'
@@ -44,7 +43,6 @@ module Java
               elsif version.to_s == '11'
                 full_version || '11.0.8.10.1'
               end
-        corretto_arch = corretto_arch
         "amazon-corretto-#{ver}-linux-#{corretto_arch}"
       end
     end

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -3,15 +3,15 @@ module Java
     module CorrettoHelpers
       def default_corretto_url(version)
         if version.to_s == '8'
-          if node['kernel']['machine'] =~ /x86_64/
+          if node['kernel']['machine'].match?('x86_64')
             'https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.tar.gz'
-          elsif node['kernel']['machine'] =~ /aarch64/
+          elsif node['kernel']['machine'].match?('aarch64')
             'https://corretto.aws/downloads/latest/amazon-corretto-8-aarch64-linux-jdk.tar.gz'
           end
-        else
-          if node['kernel']['machine'] =~ /x86_64/
+        elsif version.to_s == '11'
+          if node['kernel']['machine'].match?('x86_64')
             'https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz'
-          elsif node['kernel']['machine'] =~ /aarch64/
+          elsif node['kernel']['machine'].match?('aarch64')
             'https://corretto.aws/downloads/latest/amazon-corretto-11-aarch64-linux-jdk.tar.gz'
           end
         end
@@ -19,15 +19,15 @@ module Java
 
       def default_corretto_checksum(version)
         if version.to_s == '8'
-          if node['kernel']['machine'] =~ /x86_64/
+          if node['kernel']['machine'].match?('x86_64')
             '1db9c4bd89b9949c97bc5e690aedce2872bb716cf35c670a29cadeeb80d0cb18'
-          elsif node['kernel']['machine'] =~ /aarch64/
+          elsif node['kernel']['machine'].match?('aarch64')
             '2e3755bac052ad7c502adbaec7823328644af3767abd1169974b144805eb718e'
           end
-        else
-          if node['kernel']['machine'] =~ /x86_64/
+        elsif version.to_s == '11'
+          if node['kernel']['machine'].match?('x86_64')
             'dbbf98ca93b44a0c81df5a3a4f2cebf467ec5c30e28c359e26615ffbed0b454f'
-          elsif node['kernel']['machine'] =~ /aarch64/
+          elsif node['kernel']['machine'].match?('aarch64')
             'f278647d126d973a841d80b0b6836b723f14c63ee0d0f1804b8d4125843b13ed'
           end
         end
@@ -36,7 +36,7 @@ module Java
       def default_corretto_bin_cmds(version)
         if version.to_s == '8'
           %w(appletviewer clhsdb extcheck hsdb idlj jar jarsigner java java-rmi.cgi javac javadoc javafxpackager javah javap javapackager jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
-        else
+        elsif version.to_s == '11'
           %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
         end
       end
@@ -44,7 +44,7 @@ module Java
       def corretto_sub_dir(version, full_version = nil)
         ver = if version == '8'
                 full_version || '8.265.01.1'
-              else
+              elsif version.to_s == '11'
                 full_version || '11.0.8.10.1'
               end
         arch = node['kernel']['machine']

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -3,36 +3,52 @@ module Java
     module CorrettoHelpers
       def default_corretto_url(version)
         if version.to_s == '8'
-          'https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.tar.gz'
+          if node['kernel']['machine'] =~ /x86_64/
+            'https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.tar.gz'
+          elsif node['kernel']['machine'] =~ /aarch64/
+            'https://corretto.aws/downloads/latest/amazon-corretto-8-aarch64-linux-jdk.tar.gz'
+          end
         else
-          'https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz'
+          if node['kernel']['machine'] =~ /x86_64/
+            'https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz'
+          elsif node['kernel']['machine'] =~ /aarch64/
+            'https://corretto.aws/downloads/latest/amazon-corretto-11-aarch64-linux-jdk.tar.gz'
+          end
         end
       end
 
       def default_corretto_checksum(version)
         if version.to_s == '8'
-          '7f08bc6097a14424bf09eb693304d48812099f29edb1d7326c6372a85b86b1df'
+          if node['kernel']['machine'] =~ /x86_64/
+            '1db9c4bd89b9949c97bc5e690aedce2872bb716cf35c670a29cadeeb80d0cb18'
+          elsif node['kernel']['machine'] =~ /aarch64/
+            '2e3755bac052ad7c502adbaec7823328644af3767abd1169974b144805eb718e'
+          end
         else
-          '24a487d594d10df540383c4c642444f969a00e616331d3dc3bdc4815ada71c0e'
+          if node['kernel']['machine'] =~ /x86_64/
+            'dbbf98ca93b44a0c81df5a3a4f2cebf467ec5c30e28c359e26615ffbed0b454f'
+          elsif node['kernel']['machine'] =~ /aarch64/
+            'f278647d126d973a841d80b0b6836b723f14c63ee0d0f1804b8d4125843b13ed'
+          end
         end
       end
 
       def default_corretto_bin_cmds(version)
         if version.to_s == '8'
-          ['appletviewer', 'clhsdb', 'extcheck', 'hsdb', 'idlj', 'jar', 'jarsigner', 'java', 'java-rmi.cgi', 'javac', 'javadoc', 'javafxpackager', 'javah', 'javap', 'javapackager', 'jcmd', 'jconsole', 'jdb', 'jdeps', 'jhat', 'jinfo', 'jjs', 'jmap', 'jps', 'jrunscript', 'jsadebugd', 'jstack', 'jstat', 'jstatd', 'keytool', 'native2ascii', 'orbd', 'pack200', 'policytool', 'rmic', 'rmid', 'rmiregistry', 'schemagen', 'serialver', 'servertool', 'tnameserv', 'unpack200', 'wsgen', 'wsimport', 'xjc']
+          %w(appletviewer clhsdb extcheck hsdb idlj jar jarsigner java java-rmi.cgi javac javadoc javafxpackager javah javap javapackager jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
         else
-          %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
+          %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
         end
       end
 
       def corretto_sub_dir(version, full_version = nil)
         ver = if version == '8'
-                full_version || '8.242.08.1'
+                full_version || '8.265.01.1'
               else
-                full_version || '11.0.6.10.1'
+                full_version || '11.0.8.10.1'
               end
-
-        "amazon-corretto-#{ver}-linux-x64"
+        arch = node['kernel']['machine']
+        "amazon-corretto-#{ver}-linux-#{arch}"
       end
     end
   end

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -1,19 +1,16 @@
 module Java
   module Cookbook
     module CorrettoHelpers
+      def correto_arch
+        node['kernel']['machine'].match?('aarch64') ? 'aarch64' : 'x64'
+      end
+
       def default_corretto_url(version)
+        corretto_arch = corretto_arch
         if version.to_s == '8'
-          if node['kernel']['machine'].match?('x86_64')
-            'https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.tar.gz'
-          elsif node['kernel']['machine'].match?('aarch64')
-            'https://corretto.aws/downloads/latest/amazon-corretto-8-aarch64-linux-jdk.tar.gz'
-          end
+          "https://corretto.aws/downloads/latest/amazon-corretto-8-#{corretto_arch}-linux-jdk.tar.gz"
         elsif version.to_s == '11'
-          if node['kernel']['machine'].match?('x86_64')
-            'https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz'
-          elsif node['kernel']['machine'].match?('aarch64')
-            'https://corretto.aws/downloads/latest/amazon-corretto-11-aarch64-linux-jdk.tar.gz'
-          end
+          "https://corretto.aws/downloads/latest/amazon-corretto-11-#{corretto_arch}-linux-jdk.tar.gz"
         end
       end
 
@@ -47,8 +44,8 @@ module Java
               elsif version.to_s == '11'
                 full_version || '11.0.8.10.1'
               end
-        arch = node['kernel']['machine']
-        "amazon-corretto-#{ver}-linux-#{arch}"
+        corretto_arch = corretto_arch
+        "amazon-corretto-#{ver}-linux-#{corretto_arch}"
       end
     end
   end

--- a/spec/libraries/corretto_helpers_spec.rb
+++ b/spec/libraries/corretto_helpers_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
     context 'No full_version passed for Corretto 11' do
       let(:version) { '11' }
 
-      it 'returns the default directory value for Corrretto 8' do
+      it 'returns the default directory value for Corrretto 11' do
         expect(subject.corretto_sub_dir(version)).to include '0.6.10.1'
       end
     end

--- a/spec/libraries/corretto_helpers_spec.rb
+++ b/spec/libraries/corretto_helpers_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:full_version) { '8.123.45.6' }
       let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 8' do
+      it 'returns the default directory value for Corrretto 8 x64' do
         expect(subject.corretto_sub_dir(version, full_version)).to include '8.123.45.6'
       end
     end

--- a/spec/libraries/corretto_helpers_spec.rb
+++ b/spec/libraries/corretto_helpers_spec.rb
@@ -10,18 +10,39 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
   describe '#default_corretto_url' do
     before do
       allow(subject).to receive(:[]).with('version').and_return(version)
+      allow(subject).to receive(:[]).with('kernel').and_return('machine' => machine)
     end
 
-    context 'Corretto 8' do
+    context 'Corretto 8 x64' do
       let(:version) { '8' }
+      let(:machine) { 'x86_64' }
 
       it 'returns the correct URL' do
         expect(subject.default_corretto_url(version)).to match /corretto-8.+\.tar.gz/
       end
     end
 
-    context 'Corretto 11' do
+    context 'Corretto 11 x64' do
       let(:version) { '11' }
+      let(:machine) { 'x86_64' }
+
+      it 'returns the correct URL' do
+        expect(subject.default_corretto_url(version)).to match /corretto-11.+\.tar.gz/
+      end
+    end
+
+    context 'Corretto 8 aarch64' do
+      let(:version) { '8' }
+      let(:machine) { 'aarch64' }
+
+      it 'returns the correct URL' do
+        expect(subject.default_corretto_url(version)).to match /corretto-8.+\.tar.gz/
+      end
+    end
+
+    context 'Corretto 11 aarch64' do
+      let(:version) { '11' }
+      let(:machine) { 'aarch64' }
 
       it 'returns the correct URL' do
         expect(subject.default_corretto_url(version)).to match /corretto-11.+\.tar.gz/
@@ -56,29 +77,61 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
   describe '#corretto_sub_dir' do
     before do
       allow(subject).to receive(:[]).with('version', 'full_version').and_return(version)
+      allow(subject).to receive(:[]).with('kernel').and_return('machine' => machine)
     end
 
-    context 'No full_version passed for Corretto 8' do
+    context 'No full_version passed for Corretto 8 x64' do
       let(:version) { '8' }
+      let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 8' do
-        expect(subject.corretto_sub_dir(version)).to include '242'
+      it 'returns the default directory value for Corrretto 8 x64' do
+        expect(subject.corretto_sub_dir(version)).to include '265'
       end
     end
 
-    context 'No full_version passed for Corretto 11' do
+    context 'No full_version passed for Corretto 8 aarch64' do
+      let(:version) { '8' }
+      let(:machine) { 'aarch64' }
+
+      it 'returns the default directory value for Corrretto 8 aarch64' do
+        expect(subject.corretto_sub_dir(version)).to include '265'
+      end
+    end
+
+    context 'No full_version passed for Corretto 11 x64' do
       let(:version) { '11' }
+      let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 11' do
-        expect(subject.corretto_sub_dir(version)).to include '0.6.10.1'
+      it 'returns the default directory value for Corrretto 11 x64' do
+        expect(subject.corretto_sub_dir(version)).to include '0.8.10.1'
       end
     end
 
-    context 'A full version passed for for Corretto 8' do
+    context 'No full_version passed for Corretto 11 aarch64' do
+      let(:version) { '11' }
+      let(:machine) { 'aarch64' }
+
+      it 'returns the default directory value for Corrretto 11 aarch64' do
+        expect(subject.corretto_sub_dir(version)).to include '0.8.10.1'
+      end
+    end
+
+    context 'A full version passed for for Corretto 8 x64' do
       let(:version) { '8' }
       let(:full_version) { '8.123.45.6' }
+      let(:machine) { 'x86_64' }
 
       it 'returns the default directory value for Corrretto 8' do
+        expect(subject.corretto_sub_dir(version, full_version)).to include '8.123.45.6'
+      end
+    end
+
+    context 'A full version passed for for Corretto 8 aarch64' do
+      let(:version) { '8' }
+      let(:full_version) { '8.123.45.6' }
+      let(:machine) { 'aarch64' }
+
+      it 'returns the default directory value for Corrretto 8 aarch64' do
         expect(subject.corretto_sub_dir(version, full_version)).to include '8.123.45.6'
       end
     end


### PR DESCRIPTION
### Description

Adds ARM64 installation for corretto

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable