### PR TITLE
If installation issues with openjdk_install resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - amazon-linux
           - amazonlinux-2
           - debian-9
           - debian-10
@@ -72,8 +71,6 @@ jobs:
           - os: ubuntu-2004
             suite: openjdk-pkg-14
         exclude:
-          - os: amazon-linux
-            suite: openjdk-pkg-11
           - os: debian-9
             suite: openjdk-pkg-11
           - os: debian-10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           echo "sourced profile for JAVA_HOME"
           echo "New JAVA home after Chef run is: ${JAVA_HOME}"
           # Magic line for github actions to persist the change
-          echo ::set-env name=JAVA_HOME::$(echo ${JAVA_HOME})
+          echo "JAVA_HOME=${JAVA_HOME}" >> $GITHUB_ENV
       - name: Kitchen Verify
         uses: actionshub/test-kitchen@master
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the Java cookbook.
 - resolved cookstyle error: spec/spec_helper.rb:6:18 convention: `Style/RedundantFileExtensionInRequire`
 - resolved cookstyle error: spec/spec_helper.rb:7:18 convention: `Style/RedundantFileExtensionInRequire`
 - If installation issues with `openjdk_install` resource (fixes #645)
+- Remove testing of Amazon Linux 1
 
 ## 8.4.0 (2020-09-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the Java cookbook.
 - resolved cookstyle error: spec/spec_helper.rb:5:18 convention: `Style/RedundantFileExtensionInRequire`
 - resolved cookstyle error: spec/spec_helper.rb:6:18 convention: `Style/RedundantFileExtensionInRequire`
 - resolved cookstyle error: spec/spec_helper.rb:7:18 convention: `Style/RedundantFileExtensionInRequire`
+- If installation issues with `openjdk_install` resource (fixes #645)
 
 ## 8.4.0 (2020-09-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the Java cookbook.
 - resolved cookstyle error: spec/spec_helper.rb:7:18 convention: `Style/RedundantFileExtensionInRequire`
 - If installation issues with `openjdk_install` resource (fixes #645)
 - Remove testing of Amazon Linux 1
+- Use fedora-latest
 
 ## 8.4.0 (2020-09-09)
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -42,11 +42,6 @@ platforms:
       image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: fedora-31
-    driver:
-      image: dokken/fedora-31
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -13,11 +13,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazon-linux
-    driver:
-      image: dokken/amazonlinux
-      pid_one_command: /sbin/init
-
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,8 +18,7 @@ platforms:
   - name: debian-10
   - name: freebsd-11
   - name: freebsd-12
-  - name: fedora-31
-  - name: fedora-32
+  - name: fedora-latest
   - name: opensuse-leap-15
   - name: ubuntu-18.04
   - name: ubuntu-20.04

--- a/libraries/openjdk_helpers.rb
+++ b/libraries/openjdk_helpers.rb
@@ -117,7 +117,7 @@ module Java
         value_for_platform_family(
           amazon: version.to_i < 11 ? ["java-1.#{version}.0-openjdk", "java-1.#{version}.0-openjdk-devel"] : "java-#{version}-amazon-corretto",
           %w(rhel fedora) => version.to_i < 11 ? ["java-1.#{version}.0-openjdk", "java-1.#{version}.0-openjdk-devel"] : ["java-#{version}-openjdk", "java-#{version}-openjdk-devel"],
-          suse: ["java-1_#{version}_0-openjdk", "java-1_#{version}_0-openjdk-devel"],
+          suse: version.to_i == 8 ? ["java-1_#{version}_0-openjdk", "java-1_#{version}_0-openjdk-devel"] : ["java-#{version}-openjdk", "java-#{version}-openjdk-devel"],
           freebsd: version.to_i.eql?(7) ? 'openjdk' : "openjdk#{version}",
           arch: "openjdk#{version}",
           debian: ["openjdk-#{version}-jdk", "openjdk-#{version}-jre-headless"],
@@ -129,7 +129,7 @@ module Java
         value_for_platform_family(
           %w(rhel fedora) => version.to_i < 11 ? "/usr/lib/jvm/java-1.#{version}.0" : "/usr/lib/jvm/java-#{version}",
           amazon: version.to_i < 11 ? "/usr/lib/jvm/java-1.#{version}.0" : "/usr/lib/jvm/jre-#{version}",
-          suse: "/usr/lib#{node['kernel']['machine'] == 'x86_64' ? '64' : nil}/jvm/java-1.#{version}.0",
+          suse: "/usr/lib#{node['kernel']['machine'] == 'x86_64' ? '64' : nil}/jvm/java-#{version.to_i == 8 ? "1.#{version}.0" : version}",
           freebsd: "/usr/local/openjdk#{version}",
           arch: "/usr/lib/jvm/java-#{version}-openjdk",
           debian: "/usr/lib/jvm/java-#{version}-openjdk-#{node['kernel']['machine'] == 'x86_64' ? 'amd64' : 'i386'}",

--- a/libraries/openjdk_helpers.rb
+++ b/libraries/openjdk_helpers.rb
@@ -1,6 +1,63 @@
 module Java
   module Cookbook
     module OpenJdkHelpers
+      def default_openjdk_install_method(version)
+        case node['platform_family']
+        when 'amazon'
+          case version.to_i
+          when 7, 8, 11
+            'package'
+          else
+            'source'
+          end
+        when 'rhel', 'fedora'
+          case node['platform_version'].to_i
+          when 7
+            case version.to_i
+            when 6, 7, 8, 11
+              'package'
+            else
+              'source'
+            end
+          when 8
+            case version.to_i
+            when 8, 11
+              'package'
+            else
+              'source'
+            end
+          else
+            # Assume Fedora
+            case version.to_i
+            when 8, 11
+              'package'
+            else
+              'source'
+            end
+          end
+        when 'debian'
+          if platform?('debian')
+            case node['platform_version'].to_i
+            when 9
+              'source'
+            when 10
+              version.to_i == 11 ? 'package' : 'source'
+            end
+          else
+            version.to_i == 10 ? 'source' : 'package'
+          end
+        when 'suse'
+          case version.to_i
+          when 8, 9, 11
+            'package'
+          else
+            'source'
+          end
+        else
+          'package'
+        end
+      end
+
       def default_openjdk_url(version)
         case version
         when '9'

--- a/resources/openjdk_install.rb
+++ b/resources/openjdk_install.rb
@@ -5,7 +5,10 @@ include Java::Cookbook::OpenJdkHelpers
 default_action :install
 
 property :version, String, name_property: true, description: 'Java major version to install'
-property :install_type, String, default: 'package', equal_to: %w( package source ), description: 'Installation type'
+property :install_type, String,
+  default: lazy { default_openjdk_install_method(version) },
+  equal_to: %w( package source ),
+  description: 'Installation type'
 property :pkg_names, [String, Array], description: 'List of packages to install'
 property :pkg_version, String, description: 'Package version to install'
 property :java_home, String, description: 'Set to override the java_home'

--- a/resources/openjdk_install.rb
+++ b/resources/openjdk_install.rb
@@ -20,7 +20,7 @@ property :java_home_owner, String, description: 'Owner of the Java Home'
 property :java_home_group, String, description: 'Group for the Java Home'
 
 action :install do
-  if install_type == 'package'
+  if new_resource.install_type == 'package'
     openjdk_pkg_install new_resource.version do
       pkg_names new_resource.pkg_names
       pkg_version new_resource.pkg_version
@@ -30,7 +30,7 @@ action :install do
       alternatives_priority new_resource.alternatives_priority
       reset_alternatives new_resource.reset_alternatives
     end
-  elsif install_type == 'source'
+  elsif new_resource.install_type == 'source'
     openjdk_source_install new_resource.version do
       url new_resource.url
       checksum new_resource.checksum
@@ -48,7 +48,7 @@ action :install do
 end
 
 action :remove do
-  if install_type == 'package'
+  if new_resource.install_type == 'package'
     openjdk_pkg_install new_resource.version do
       pkg_names new_resource.pkg_names
       pkg_version new_resource.pkg_version
@@ -59,7 +59,7 @@ action :remove do
       reset_alternatives new_resource.reset_alternatives
       action :remove
     end
-  elsif install_type == 'source'
+  elsif new_resource.install_type == 'source'
     openjdk_source_install new_resource.version do
       url new_resource.url
       checksum new_resource.checksum

--- a/resources/openjdk_source_install.rb
+++ b/resources/openjdk_source_install.rb
@@ -1,5 +1,5 @@
-resource_name :openjdk_install
-provides :openjdk_install
+resource_name :openjdk_source_install
+provides :openjdk_source_install
 
 include Java::Cookbook::OpenJdkHelpers
 default_action :install

--- a/test/integration/openjdk/controls/verify_openjdk.rb
+++ b/test/integration/openjdk/controls/verify_openjdk.rb
@@ -9,6 +9,12 @@ control 'Java is installed & linked correctly' do
   end
 
   describe command('update-alternatives --display jar') do
-    its('stdout') { should match %r{\/usr\/lib\/jvm\/java} }
+    # the openjdk 11 package on amazon linux 2 creates a symbolic link
+    # using jre-<version> rather than java-<version> like the other platforms.
+    if os[:name] == 'amazon' && os[:release].start_with?('2') && java_version.to_i == 11
+      its('stdout') { should match %r{\/usr\/lib\/jvm\/jre} }
+    else
+      its('stdout') { should match %r{\/usr\/lib\/jvm\/java} }
+    end
   end
 end


### PR DESCRIPTION
This actually fixes two issues:

- Properly fix `resource_name` and `provides` parameters in
  `openjdk_source_install` resource as `openjdk_source_install`.
- Use `new_resource.install` when references parameters in `openjdk_install`

This resolves #645.

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable