### PR TITLE
Adds Amazon Corretto 15 support, changes to `java_certificate`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,9 @@ jobs:
           - adoptopenjdk-14-openj9
           - adoptopenjdk-14-openj9-large-heap
           - adoptopenjdk-removal-11-openj9
-          # - corretto-11
-          # - corretto-8
+          - corretto-8
+          - corretto-11
+          - corretto-15
           - custom-package-8
           - custom-package-11
           - custom-package-11-openj9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Added Amazon Corretto 15 support to `corretto_install`
+- Added configurable `file_cache_path` property to `java_certificate`
+- Added `cacerts` property to `java_certificate` for interacting with java cacerts file (Java 9+)
+
 ## 8.5.0 - *2020-12-03*
 
 - resolved cookstyle error: spec/spec_helper.rb:4:18 convention: `Style/RedundantFileExtensionInRequire`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![OpenCollective](https://opencollective.com/sous-chefs/sponsors/badge.svg)](#sponsors)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This cookbook installs a Java JDK/JRE. It defaults to installing OpenJDK, but it can also install AdoptOpenJDK.
+This cookbook installs a Java JDK/JRE. It defaults to installing [OpenJDK](https://openjdk.java.net/), but it can also install [AdoptOpenJDK](https://adoptopenjdk.net/) and [Amazon Corretto](https://corretto.aws/).
 
 ## Maintainers
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -28,70 +28,70 @@ suites:
   - name: openjdk-10
     run_list:
       - recipe[test::openjdk]
-    attributes: { version: '10' }
+    attributes: {version: "10"}
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: { java_version: '10' }
+      inputs: {java_version: "10"}
 
   - name: openjdk-11
     run_list:
       - recipe[test::openjdk]
-    attributes: { version: '11' }
+    attributes: {version: "11"}
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: { java_version: '11' }
+      inputs: {java_version: "11"}
 
   - name: openjdk-12
     run_list:
       - recipe[test::openjdk]
-    attributes: { version: '12' }
+    attributes: {version: "12"}
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: { java_version: '12' }
+      inputs: {java_version: "12"}
 
   - name: openjdk-13
     run_list:
       - recipe[test::openjdk]
-    attributes: { version: '13' }
+    attributes: {version: "13"}
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: { java_version: '13' }
+      inputs: {java_version: "13"}
 
   # OpenJDK_PKG
   - name: openjdk-pkg-7
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: { version: '7' }
+    attributes: {version: "7"}
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: { java_version: '7' }
-    includes: ['amazon-linux', 'amazonlinux-2', 'centos-7']
+      inputs: {java_version: "7"}
+    includes: ["amazon-linux", "amazonlinux-2", "centos-7"]
 
   - name: openjdk-pkg-8
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: { version: '8' }
+    attributes: {version: "8"}
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: { java_version: '8' }
-    excludes: ['debian-10']
+      inputs: {java_version: "8"}
+    excludes: ["debian-10"]
 
   - name: openjdk-pkg-11
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: { version: '11' }
+    attributes: {version: "11"}
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: { java_version: '11' }
-    excludes: ['amazon-linux', 'debian-9']
+      inputs: {java_version: "11"}
+    excludes: ["amazon-linux", "debian-9"]
 
   - name: openjdk-pkg-14
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: { version: '14' }
+    attributes: {version: "14"}
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: { java_version: '14' }
+      inputs: {java_version: "14"}
     includes: [ubuntu-20.04]
 
   # AdoptOpenJDK
@@ -214,24 +214,24 @@ suites:
   - name: corretto-8
     run_list:
       - recipe[test::corretto]
-    attributes: { version: '8' }
+    attributes: {version: "8"}
     verifier:
       inspec_tests: [test/integration/corretto]
-      inputs: { java_version: '8' }
+      inputs: {java_version: "8"}
   - name: corretto-11
     run_list:
       - recipe[test::corretto]
-    attributes: { version: '11' }
+    attributes: {version: "11"}
     verifier:
       inspec_tests: [test/integration/corretto]
-      inputs: { java_version: '11' }
+      inputs: {java_version: "11"}
   - name: corretto-15
     run_list:
       - recipe[test::corretto]
-    attributes: { version: '15' }
+    attributes: {version: "15"}
     verifier:
       inspec_tests: [test/integration/corretto]
-      inputs: { java_version: '15' }
+      inputs: {java_version: "15"}
 
   # Custom URL tests
   - name: custom-package-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -28,70 +28,70 @@ suites:
   - name: openjdk-10
     run_list:
       - recipe[test::openjdk]
-    attributes: {version: '10'}
+    attributes: { version: '10' }
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: {java_version: '10'}
+      inputs: { java_version: '10' }
 
   - name: openjdk-11
     run_list:
       - recipe[test::openjdk]
-    attributes: {version: '11'}
+    attributes: { version: '11' }
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: {java_version: '11'}
+      inputs: { java_version: '11' }
 
   - name: openjdk-12
     run_list:
       - recipe[test::openjdk]
-    attributes: {version: '12'}
+    attributes: { version: '12' }
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: {java_version: '12'}
+      inputs: { java_version: '12' }
 
   - name: openjdk-13
     run_list:
       - recipe[test::openjdk]
-    attributes: {version: '13'}
+    attributes: { version: '13' }
     verifier:
       inspec_tests: [test/integration/openjdk]
-      inputs: {java_version: '13'}
+      inputs: { java_version: '13' }
 
   # OpenJDK_PKG
   - name: openjdk-pkg-7
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: {version: '7'}
+    attributes: { version: '7' }
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: {java_version: '7'}
-    includes: ["amazon-linux", "amazonlinux-2", "centos-7"]
+      inputs: { java_version: '7' }
+    includes: ['amazon-linux', 'amazonlinux-2', 'centos-7']
 
   - name: openjdk-pkg-8
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: {version: '8'}
+    attributes: { version: '8' }
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: {java_version: '8'}
-    excludes: ["debian-10"]
+      inputs: { java_version: '8' }
+    excludes: ['debian-10']
 
   - name: openjdk-pkg-11
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: {version: '11'}
+    attributes: { version: '11' }
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: {java_version: '11'}
-    excludes: ["amazon-linux", "debian-9"]
+      inputs: { java_version: '11' }
+    excludes: ['amazon-linux', 'debian-9']
 
   - name: openjdk-pkg-14
     run_list:
       - recipe[test::openjdk_pkg]
-    attributes: {version: '14'}
+    attributes: { version: '14' }
     verifier:
       inspec_tests: [test/integration/openjdk_pkg]
-      inputs: {java_version: '14'}
+      inputs: { java_version: '14' }
     includes: [ubuntu-20.04]
 
   # AdoptOpenJDK
@@ -104,7 +104,8 @@ suites:
       variant: hotspot
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-8-hotspot.yml]
+      input_files:
+        [test/integration/adoptopenjdk/attributes/adoptopenjdk-8-hotspot.yml]
   - name: adoptopenjdk-8-openj9
     run_list:
       - recipe[test::adoptopenjdk]
@@ -113,7 +114,8 @@ suites:
       variant: openj9
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-8-openj9.yml]
+      input_files:
+        [test/integration/adoptopenjdk/attributes/adoptopenjdk-8-openj9.yml]
   - name: adoptopenjdk-8-openj9-large-heap
     run_list:
       - recipe[test::adoptopenjdk]
@@ -122,7 +124,10 @@ suites:
       variant: openj9-large-heap
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-8-openj9-large-heap.yml]
+      input_files:
+        [
+          test/integration/adoptopenjdk/attributes/adoptopenjdk-8-openj9-large-heap.yml,
+        ]
 
   # Version 11
   - name: adoptopenjdk-11-hotspot
@@ -133,7 +138,8 @@ suites:
       variant: hotspot
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-11-hotspot.yml]
+      input_files:
+        [test/integration/adoptopenjdk/attributes/adoptopenjdk-11-hotspot.yml]
   - name: adoptopenjdk-11-openj9
     run_list:
       - recipe[test::adoptopenjdk]
@@ -142,7 +148,8 @@ suites:
       variant: openj9
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-11-openj9.yml]
+      input_files:
+        [test/integration/adoptopenjdk/attributes/adoptopenjdk-11-openj9.yml]
   - name: adoptopenjdk-11-openj9-large-heap
     run_list:
       - recipe[test::adoptopenjdk]
@@ -151,7 +158,10 @@ suites:
       variant: openj9-large-heap
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-11-openj9-large-heap.yml]
+      input_files:
+        [
+          test/integration/adoptopenjdk/attributes/adoptopenjdk-11-openj9-large-heap.yml,
+        ]
 
   # Version 14
   - name: adoptopenjdk-14-openj9-large-heap
@@ -162,7 +172,10 @@ suites:
       variant: openj9-large-heap
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-14-openj9-large-heap.yml]
+      input_files:
+        [
+          test/integration/adoptopenjdk/attributes/adoptopenjdk-14-openj9-large-heap.yml,
+        ]
   - name: adoptopenjdk-14-openj9
     run_list:
       - recipe[test::adoptopenjdk]
@@ -172,7 +185,8 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/adoptopenjdk
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-14-openj9.yml]
+      input_files:
+        [test/integration/adoptopenjdk/attributes/adoptopenjdk-14-openj9.yml]
   - name: adoptopenjdk-14-hotspot
     run_list:
       - recipe[test::adoptopenjdk]
@@ -181,7 +195,8 @@ suites:
       variant: hotspot
     verifier:
       inspec_tests: [test/integration/adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-14-hotspot.yml]
+      input_files:
+        [test/integration/adoptopenjdk/attributes/adoptopenjdk-14-hotspot.yml]
 
   # 11 Removal
   - name: adoptopenjdk-removal-11-openj9
@@ -192,23 +207,31 @@ suites:
       variant: openj9
     verifier:
       inspec_tests: [test/integration/remove-adoptopenjdk]
-      input_files: [test/integration/adoptopenjdk/attributes/adoptopenjdk-11-openj9.yml]
+      input_files:
+        [test/integration/adoptopenjdk/attributes/adoptopenjdk-11-openj9.yml]
 
   # Corretto
   - name: corretto-8
     run_list:
       - recipe[test::corretto]
-    attributes: {version: '8'}
+    attributes: { version: '8' }
     verifier:
       inspec_tests: [test/integration/corretto]
-      inputs: {java_version: '8'}
+      inputs: { java_version: '8' }
   - name: corretto-11
     run_list:
       - recipe[test::corretto]
-    attributes: {version: '11'}
+    attributes: { version: '11' }
     verifier:
       inspec_tests: [test/integration/corretto]
-      inputs: {java_version: '11'}
+      inputs: { java_version: '11' }
+  - name: corretto-15
+    run_list:
+      - recipe[test::corretto]
+    attributes: { version: '15' }
+    verifier:
+      inspec_tests: [test/integration/corretto]
+      inputs: { java_version: '15' }
 
   # Custom URL tests
   - name: custom-package-8
@@ -254,4 +277,5 @@ suites:
       checksum: 6524d85d2ce334c955a4347015567326067ef15fe5f6a805714b25cace256f40
     verifier:
       inspec_tests: [test/integration/custom-package]
-      input_files: [test/integration/custom-package/attributes/openj9-large-heap-11.yml]
+      input_files:
+        [test/integration/custom-package/attributes/openj9-large-heap-11.yml]

--- a/libraries/certificate_helpers.rb
+++ b/libraries/certificate_helpers.rb
@@ -1,0 +1,21 @@
+module Java
+  module Cookbook
+    module CertificateHelpers
+      def default_truststore_path(version, java_home)
+        if version.to_i > 8
+          "#{java_home}/lib/security/cacerts"
+        else
+          "#{java_home}/jre/lib/security/cacerts"
+        end
+      end
+
+      def keystore_argument(version, cacerts, truststore_path)
+        if version.to_i > 8 && cacerts
+          '-cacerts'
+        else
+          "-keystore #{truststore_path}"
+        end
+      end
+    end
+  end
+end

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -18,15 +18,15 @@ module Java
       def default_corretto_checksum(version)
         if version.to_s == '8'
           if node['kernel']['machine'].match?('x86_64')
-            '25415701c864ec301975097f207e909d065eb7c452a501c0e4b4487e77fbdc7a'
+            '5db96ea7c5fa34de4eadbc41e2adf1fccb7e373b5788f77e26e0d69b9e368b7f'
           elsif node['kernel']['machine'].match?('aarch64')
-            '7b86c40410c75de44c311fe127bb1dd02c43040312d66b1363737ab3e7d77011'
+            '124875d5d2b3b540d40a584605385c03e71bf57f782baf5130e0bfee18b680c1'
           end
         elsif version.to_s == '11'
           if node['kernel']['machine'].match?('x86_64')
-            '448494766be37bb8a4ecd983a09742d28b1fa426684417b0dec2f3b03c44f3a3'
+            'bf9380ee0cdd78fafb6d0cdfa0c1a97baaaec44432a15c8c2f296696ad9ed631'
           elsif node['kernel']['machine'].match?('aarch64')
-            'e25669eb74d6c270af303bc0d1d859dd9ff16a0288f00a9d0ba4105467fc9695'
+            '18f4716151f4786abe6b185aab2cc5f5ad7b15f899d7eb143a81ccda8690f6f6'
           end
         elsif version.to_s == '15'
           if node['kernel']['machine'].match?('x86_64')
@@ -49,9 +49,9 @@ module Java
 
       def corretto_sub_dir(version, full_version = nil)
         ver = if version == '8'
-                full_version || '8.275.01.1'
+                full_version || '8.282.08.1'
               elsif version.to_s == '11'
-                full_version || '11.0.9.12.1'
+                full_version || '11.0.10.9.1'
               elsif version.to_s == '15'
                 full_version || '15.0.1.9.1'
               end

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -51,7 +51,7 @@ module Java
         ver = if version == '8'
                 full_version || '8.275.01.1'
               elsif version.to_s == '11'
-                full_version || '11.0.9.11.1'
+                full_version || '11.0.9.12.1'
               elsif version.to_s == '15'
                 full_version || '15.0.1.9.1'
               end

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -10,21 +10,29 @@ module Java
           "https://corretto.aws/downloads/latest/amazon-corretto-8-#{corretto_arch}-linux-jdk.tar.gz"
         elsif version.to_s == '11'
           "https://corretto.aws/downloads/latest/amazon-corretto-11-#{corretto_arch}-linux-jdk.tar.gz"
+        elsif version.to_s == '15'
+          "https://corretto.aws/downloads/latest/amazon-corretto-15-#{corretto_arch}-linux-jdk.tar.gz"
         end
       end
 
       def default_corretto_checksum(version)
         if version.to_s == '8'
           if node['kernel']['machine'].match?('x86_64')
-            '1db9c4bd89b9949c97bc5e690aedce2872bb716cf35c670a29cadeeb80d0cb18'
+            '25415701c864ec301975097f207e909d065eb7c452a501c0e4b4487e77fbdc7a'
           elsif node['kernel']['machine'].match?('aarch64')
-            '2e3755bac052ad7c502adbaec7823328644af3767abd1169974b144805eb718e'
+            '7b86c40410c75de44c311fe127bb1dd02c43040312d66b1363737ab3e7d77011'
           end
         elsif version.to_s == '11'
           if node['kernel']['machine'].match?('x86_64')
-            'dbbf98ca93b44a0c81df5a3a4f2cebf467ec5c30e28c359e26615ffbed0b454f'
+            '448494766be37bb8a4ecd983a09742d28b1fa426684417b0dec2f3b03c44f3a3'
           elsif node['kernel']['machine'].match?('aarch64')
-            'f278647d126d973a841d80b0b6836b723f14c63ee0d0f1804b8d4125843b13ed'
+            'e25669eb74d6c270af303bc0d1d859dd9ff16a0288f00a9d0ba4105467fc9695'
+          end
+        elsif version.to_s == '15'
+          if node['kernel']['machine'].match?('x86_64')
+            '6bd07d74e11deeba9f8927f8353aa689ffaa2ada263b09a4c297c0c58887af0f'
+          elsif node['kernel']['machine'].match?('aarch64')
+            'e5112fec0f4e6f3de048c5bd6a9a690dd07344436985755636df6dc18b4bfb62'
           end
         end
       end
@@ -34,14 +42,18 @@ module Java
           %w(appletviewer clhsdb extcheck hsdb idlj jar jarsigner java java-rmi.cgi javac javadoc javafxpackager javah javap javapackager jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
         elsif version.to_s == '11'
           %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
+        elsif version.to_s == '15'
+          %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver)
         end
       end
 
       def corretto_sub_dir(version, full_version = nil)
         ver = if version == '8'
-                full_version || '8.265.01.1'
+                full_version || '8.275.01.1'
               elsif version.to_s == '11'
-                full_version || '11.0.8.10.1'
+                full_version || '11.0.9.11.1'
+              elsif version.to_s == '15'
+                full_version || '15.0.1.9.1'
               end
         "amazon-corretto-#{ver}-linux-#{corretto_arch}"
       end

--- a/spec/libraries/certificate_helpers_spec.rb
+++ b/spec/libraries/certificate_helpers_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe Java::Cookbook::CertificateHelpers do
+  class DummyClass < Chef::Node
+    include Java::Cookbook::CertificateHelpers
+  end
+
+  subject { DummyClass.new }
+
+  describe '#default_truststore_path' do
+    context 'Java 8' do
+      let(:version) { '8' }
+      let(:java_home) { '/usr/lib/jvm/corretto-8' }
+
+      it 'returns the correct path' do
+        expect(subject.default_truststore_path(version, java_home)).to eq('/usr/lib/jvm/corretto-8/jre/lib/security/cacerts')
+      end
+    end
+
+    context 'Java 9' do
+      let(:version) { '9' }
+      let(:java_home) { '/usr/lib/jvm/corretto-9' }
+
+      it 'returns the correct path' do
+        expect(subject.default_truststore_path(version, java_home)).to eq('/usr/lib/jvm/corretto-9/lib/security/cacerts')
+      end
+    end
+  end
+
+  describe '#keystore_argument' do
+    context 'Java 8 and cacerts' do
+      let(:version) { '8' }
+      let(:cacerts) { true }
+      let(:truststore_path) { '/usr/lib/jvm/corretto-8/jre/lib/security/cacerts' }
+
+      it 'returns the correct argument' do
+        expect(subject.keystore_argument(version, cacerts, truststore_path)).to eq('-keystore /usr/lib/jvm/corretto-8/jre/lib/security/cacerts')
+      end
+    end
+
+    context 'Java 9 and cacerts' do
+      let(:version) { '9' }
+      let(:cacerts) { true }
+      let(:truststore_path) { '/usr/lib/jvm/corretto-9/jre/lib/security/cacerts' }
+
+      it 'returns the correct argument' do
+        expect(subject.keystore_argument(version, cacerts, truststore_path)).to eq('-cacerts')
+      end
+    end
+
+    context 'Java 9 and no cacerts' do
+      let(:version) { '9' }
+      let(:cacerts) { false }
+      let(:truststore_path) { '/mycertstore.jks' }
+
+      it 'returns the correct argument' do
+        expect(subject.keystore_argument(version, cacerts, truststore_path)).to eq('-keystore /mycertstore.jks')
+      end
+    end
+  end
+end

--- a/spec/libraries/corretto_helpers_spec.rb
+++ b/spec/libraries/corretto_helpers_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'x86_64' }
 
       it 'returns the default directory value for Corrretto 11 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '11.0.9.11.1'
+        expect(subject.corretto_sub_dir(version)).to include '11.0.9.12.1'
       end
     end
 
@@ -139,7 +139,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'aarch64' }
 
       it 'returns the default directory value for Corrretto 11 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '11.0.9.11.1'
+        expect(subject.corretto_sub_dir(version)).to include '11.0.9.12.1'
       end
     end
 

--- a/spec/libraries/corretto_helpers_spec.rb
+++ b/spec/libraries/corretto_helpers_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'x86_64' }
 
       it 'returns the default directory value for Corrretto 8 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '275'
+        expect(subject.corretto_sub_dir(version)).to include '8.282.08.1'
       end
     end
 
@@ -121,7 +121,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'aarch64' }
 
       it 'returns the default directory value for Corrretto 8 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '275'
+        expect(subject.corretto_sub_dir(version)).to include '8.282.08.1'
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'x86_64' }
 
       it 'returns the default directory value for Corrretto 11 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '11.0.9.12.1'
+        expect(subject.corretto_sub_dir(version)).to include '11.0.10.9.1'
       end
     end
 
@@ -139,7 +139,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'aarch64' }
 
       it 'returns the default directory value for Corrretto 11 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '11.0.9.12.1'
+        expect(subject.corretto_sub_dir(version)).to include '11.0.10.9.1'
       end
     end
 

--- a/spec/libraries/corretto_helpers_spec.rb
+++ b/spec/libraries/corretto_helpers_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       end
     end
 
+    context 'Corretto 15 x64' do
+      let(:version) { '15' }
+      let(:machine) { 'x86_64' }
+
+      it 'returns the correct URL' do
+        expect(subject.default_corretto_url(version)).to match /corretto-15.+\.tar.gz/
+      end
+    end
+
     context 'Corretto 8 aarch64' do
       let(:version) { '8' }
       let(:machine) { 'aarch64' }
@@ -46,6 +55,15 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
 
       it 'returns the correct URL' do
         expect(subject.default_corretto_url(version)).to match /corretto-11.+\.tar.gz/
+      end
+    end
+
+    context 'Corretto 15 aarch64' do
+      let(:version) { '15' }
+      let(:machine) { 'aarch64' }
+
+      it 'returns the correct URL' do
+        expect(subject.default_corretto_url(version)).to match /corretto-15.+\.tar.gz/
       end
     end
   end
@@ -72,6 +90,15 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
         expect(subject.default_corretto_bin_cmds(version)).to include 'jaotc'
       end
     end
+
+    context 'Corretto 15' do
+      let(:version) { '15' }
+
+      it 'returns the correct bin command array' do
+        expect(subject.default_corretto_bin_cmds(version)).to_not include 'unpack200'
+        expect(subject.default_corretto_bin_cmds(version)).to include 'jaotc'
+      end
+    end
   end
 
   describe '#corretto_sub_dir' do
@@ -85,7 +112,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'x86_64' }
 
       it 'returns the default directory value for Corrretto 8 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '265'
+        expect(subject.corretto_sub_dir(version)).to include '275'
       end
     end
 
@@ -94,7 +121,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'aarch64' }
 
       it 'returns the default directory value for Corrretto 8 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '265'
+        expect(subject.corretto_sub_dir(version)).to include '275'
       end
     end
 
@@ -103,7 +130,7 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'x86_64' }
 
       it 'returns the default directory value for Corrretto 11 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '0.8.10.1'
+        expect(subject.corretto_sub_dir(version)).to include '11.0.9.11.1'
       end
     end
 
@@ -112,7 +139,25 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       let(:machine) { 'aarch64' }
 
       it 'returns the default directory value for Corrretto 11 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '0.8.10.1'
+        expect(subject.corretto_sub_dir(version)).to include '11.0.9.11.1'
+      end
+    end
+
+    context 'No full_version passed for Corretto 15 x64' do
+      let(:version) { '15' }
+      let(:machine) { 'x86_64' }
+
+      it 'returns the default directory value for Corrretto 15 x64' do
+        expect(subject.corretto_sub_dir(version)).to include '15.0.1.9.1'
+      end
+    end
+
+    context 'No full_version passed for Corretto 15 aarch64' do
+      let(:version) { '15' }
+      let(:machine) { 'aarch64' }
+
+      it 'returns the default directory value for Corrretto 15 aarch64' do
+        expect(subject.corretto_sub_dir(version)).to include '15.0.1.9.1'
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'chefspec/berkshelf'
 
 require_relative '../libraries/adopt_openjdk_helpers'
 require_relative '../libraries/adopt_openjdk_macos_helpers'
+require_relative '../libraries/certificate_helpers'
 require_relative '../libraries/corretto_helpers'
 require_relative '../libraries/openjdk_helpers'
 


### PR DESCRIPTION
### Description

Adds Amazon Corretto 15 support
Adds configurable file cache property to `java_certificate`
Adds `cacerts` property for interacting with java cacerts file for Java 9+

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable