### PR TITLE
unified_mode & Corretto checksum fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Remove Corretto checksum code defualts as this changes reguarly,
+    and is not provide in the SHA256 format via an API
+- Set unified_mode to true for Chef 17 support
+- Bump the minimum Chef version to 15.3 for unified_mode support
+
 ## 8.6.1 - *2021-06-01*
 
 ## 8.6.0 - *2021-01-22*

--- a/documentation/resources/corretto_install.md
+++ b/documentation/resources/corretto_install.md
@@ -16,7 +16,7 @@ Introduced: v8.0.0
 | version               | String          |                                      | Java version to install                                                                                           |
 | full_version          | String          |                                      | Used to configure the package directory, change this is the version installed by the package is no longer correct |
 | url                   | String          | `default_corretto_url(version)`      | The URL to download from                                                                                          |
-| checksum              | String          | `default_corretto_checksum(version)` | The checksum for the downloaded file                                                                              |
+| checksum              | String          |                                      | The checksum for the downloaded file                                                                              |
 | java_home             | String          | Based on the version                 | Set to override the java_home                                                                                     |
 | java_home_mode        | Integer, String | `0755`                               | The permission for the Java home directory                                                                        |
 | java_home_owner       | String          | `root`                               | Owner of the Java Home                                                                                            |

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -15,28 +15,6 @@ module Java
         end
       end
 
-      def default_corretto_checksum(version)
-        if version.to_s == '8'
-          if node['kernel']['machine'].match?('x86_64')
-            '5db96ea7c5fa34de4eadbc41e2adf1fccb7e373b5788f77e26e0d69b9e368b7f'
-          elsif node['kernel']['machine'].match?('aarch64')
-            '124875d5d2b3b540d40a584605385c03e71bf57f782baf5130e0bfee18b680c1'
-          end
-        elsif version.to_s == '11'
-          if node['kernel']['machine'].match?('x86_64')
-            'bf9380ee0cdd78fafb6d0cdfa0c1a97baaaec44432a15c8c2f296696ad9ed631'
-          elsif node['kernel']['machine'].match?('aarch64')
-            '18f4716151f4786abe6b185aab2cc5f5ad7b15f899d7eb143a81ccda8690f6f6'
-          end
-        elsif version.to_s == '15'
-          if node['kernel']['machine'].match?('x86_64')
-            '6bd07d74e11deeba9f8927f8353aa689ffaa2ada263b09a4c297c0c58887af0f'
-          elsif node['kernel']['machine'].match?('aarch64')
-            'e5112fec0f4e6f3de048c5bd6a9a690dd07344436985755636df6dc18b4bfb62'
-          end
-        end
-      end
-
       def default_corretto_bin_cmds(version)
         if version.to_s == '8'
           %w(appletviewer clhsdb extcheck hsdb idlj jar jarsigner java java-rmi.cgi javac javadoc javafxpackager javah javap javapackager jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license           'Apache-2.0'
 description       'Recipes and resources for installing Java and managing certificates'
 source_url        'https://github.com/sous-chefs/java'
 issues_url        'https://github.com/sous-chefs/java/issues'
-chef_version      '>= 15.0'
+chef_version      '>= 15.3'
 version           '8.6.1'
 
 supports 'debian'

--- a/resources/adoptopenjdk_install.rb
+++ b/resources/adoptopenjdk_install.rb
@@ -1,7 +1,5 @@
-resource_name :adoptopenjdk_install
 provides :adoptopenjdk_install
-
-default_action :install
+unified_mode true
 
 # Common options
 property :version, String, name_property: true, description: 'Java version to install'

--- a/resources/adoptopenjdk_linux_install.rb
+++ b/resources/adoptopenjdk_linux_install.rb
@@ -1,7 +1,7 @@
-resource_name :adoptopenjdk_linux_install
 provides :adoptopenjdk_linux_install
-
+unified_mode true
 include Java::Cookbook::AdoptOpenJdkHelpers
+
 property :version, String, name_property: true, description: 'Java version to install'
 
 property :variant, String,

--- a/resources/adoptopenjdk_macos_install.rb
+++ b/resources/adoptopenjdk_macos_install.rb
@@ -1,6 +1,5 @@
-resource_name :adoptopenjdk_macos_install
 provides :adoptopenjdk_macos_install
-
+unified_mode true
 include Java::Cookbook::AdoptOpenJdkMacOsHelpers
 
 property :tap_full, [true, false],

--- a/resources/alternatives.rb
+++ b/resources/alternatives.rb
@@ -1,18 +1,4 @@
-#
-# Cookbook:: java
-# Resource:: alternatives
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+unified_mode true
 
 property :java_location, String,
   description: 'Java installation location'

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -1,23 +1,4 @@
-#
-# Author:: Mevan Samaratunga (<mevansam@gmail.com>)
-# Author:: Michael Goetz (<mpgoetz@gmail.com>)
-# Cookbook:: java
-# Resource:: certificate
-#
-# Copyright:: 2013, Mevan Samaratunga
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+unified_mode true
 include Java::Cookbook::CertificateHelpers
 
 property :cert_alias, String,

--- a/resources/corretto_install.rb
+++ b/resources/corretto_install.rb
@@ -1,6 +1,5 @@
-resource_name :corretto_install
 provides :corretto_install
-
+unified_mode true
 include Java::Cookbook::CorrettoHelpers
 
 property :version, String, name_property: true, description: 'Java version to install'
@@ -13,7 +12,6 @@ property :url, String,
 
 property :checksum, String,
   regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
-  default: lazy { default_corretto_checksum(version) },
   description: 'The checksum for the downloaded file'
 
 property :java_home, String,
@@ -62,7 +60,7 @@ action :install do
 
   remote_file "#{Chef::Config[:file_cache_path]}/#{tarball_name}" do
     source new_resource.url
-    checksum new_resource.checksum
+    checksum new_resource.checksum if new_resource.checksum
     retries new_resource.retries
     retry_delay new_resource.retry_delay
     mode '644'

--- a/resources/jce.rb
+++ b/resources/jce.rb
@@ -1,18 +1,4 @@
-#
-# Cookbook:: java
-# Resource:: jce
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+unified_mode true
 
 property :jdk_version, String, default: lazy { node['java']['jdk_version'].to_s }, description: 'The Java version to install into'
 property :jce_url, String, default: lazy { node['java']['oracle']['jce'][jdk_version]['url'] }, description: 'The URL for the JCE distribution'

--- a/resources/openjdk_install.rb
+++ b/resources/openjdk_install.rb
@@ -1,8 +1,6 @@
-resource_name :openjdk_install
 provides :openjdk_install
-
+unified_mode true
 include Java::Cookbook::OpenJdkHelpers
-default_action :install
 
 property :version, String, name_property: true, description: 'Java major version to install'
 property :install_type, String,

--- a/resources/openjdk_pkg_install.rb
+++ b/resources/openjdk_pkg_install.rb
@@ -1,8 +1,6 @@
-resource_name :openjdk_pkg_install
 provides :openjdk_pkg_install
-
+unified_mode true
 include Java::Cookbook::OpenJdkHelpers
-default_action :install
 
 property :version, String,
   name_property: true,

--- a/resources/openjdk_source_install.rb
+++ b/resources/openjdk_source_install.rb
@@ -1,8 +1,6 @@
-resource_name :openjdk_source_install
 provides :openjdk_source_install
-
+unified_mode true
 include Java::Cookbook::OpenJdkHelpers
-default_action :install
 
 property :version, String,
   name_property: true,


### PR DESCRIPTION
- Remove Corretto checksum code defaults as this changes regularly,
    and is not provide in the SHA256 format via an API
- Set unified_mode to true for Chef 17 support
- Bump the minimum Chef version to 15.3 for unified_mode support

### Issues Resolved

- Corretto checksums fail tests regularly

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable