### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:1:11 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:2:16 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:3:31 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:6:40 convention: `Layout/ClosingParenthesisIndentation`
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:7:22 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:10:21 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:13:30 convention: `Layout/ClosingParenthesisIndentation`
+- resolved cookstyle error: test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb:14:21 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/custom-package/controls/verify_home.rb:1:11 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/custom-package/controls/verify_home.rb:2:16 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/custom-package/controls/verify_home.rb:3:22 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/custom-package/controls/verify_home.rb:6:17 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/remove-adoptopenjdk/controls/verify_adoptopenjdk-removal.rb:1:11 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/remove-adoptopenjdk/controls/verify_adoptopenjdk-removal.rb:2:24 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/remove-adoptopenjdk/controls/verify_adoptopenjdk-removal.rb:5:16 warning: `InSpec/Deprecations/AttributeHelper`
+- resolved cookstyle error: test/integration/remove-adoptopenjdk/controls/verify_adoptopenjdk-removal.rb:8:13 warning: `InSpec/Deprecations/AttributeHelper`
 ## 9.0.0 - *2021-06-04*
 
 - Remove Corretto checksum code defualts as this changes reguarly,

--- a/test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb
+++ b/test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb
@@ -1,17 +1,17 @@
-variant = attribute('variant', description: 'Variant being used: openj9, openj9-large-heap, or hotspot')
-java_version = attribute('java_version', description: 'Which version of java should be installed')
-certificate_sha256_checksum = attribute('certificate_sha256_checksum',
+variant = input('variant', description: 'Variant being used: openj9, openj9-large-heap, or hotspot')
+java_version = input('java_version', description: 'Which version of java should be installed')
+certificate_sha256_checksum = input('certificate_sha256_checksum',
                                         value: '64:F3:3B:A7:EF:C3:5C:6B:2D:ED:95:0B:CB:4E:96:3B:12:97:B8:62:BA:1A:8E:30:13:B0:B0:59:77:12:31:EA',
                                         description: 'The SHA256 checksum of the certificate'
-                                       )
-parent_install_dir = attribute('parent_install_dir',
+)
+parent_install_dir = input('parent_install_dir',
                       value: "java-#{java_version.to_i > 8 ? java_version.to_i : java_version.split('.')[1]}-adoptopenjdk-#{variant}",
                       description: 'The parent of the Java home')
-keystore_location = attribute('keystore_location',
+keystore_location = input('keystore_location',
                               value: nil,
                               description: 'Where the java keystore is located'
-                             )
-keystore_password = attribute('keystore_password',
+)
+keystore_password = input('keystore_password',
                               value: 'changeit',
                               description: 'Password to the Java keystore')
 

--- a/test/integration/custom-package/controls/verify_home.rb
+++ b/test/integration/custom-package/controls/verify_home.rb
@@ -1,9 +1,9 @@
-variant = attribute('variant', description: 'Variant being used: openj9, openj9-large-heap, or hotspot')
-java_version = attribute('java_version', description: 'Which version of java should be installed')
-parent_install_dir = attribute('parent_install_dir',
+variant = input('variant', description: 'Variant being used: openj9, openj9-large-heap, or hotspot')
+java_version = input('java_version', description: 'Which version of java should be installed')
+parent_install_dir = input('parent_install_dir',
                      value: "java-#{java_version.to_i > 8 ? java_version.to_i : java_version.split('.')[1]}-adoptopenjdk-#{variant}",
                      description: 'The parent of the Java home')
-java_home_dir = attribute('java_home_dir', description: 'Name of the JAVA_HOME directory')
+java_home_dir = input('java_home_dir', description: 'Name of the JAVA_HOME directory')
 
 control 'check-java-version' do
   impact 1.0

--- a/test/integration/remove-adoptopenjdk/controls/verify_adoptopenjdk-removal.rb
+++ b/test/integration/remove-adoptopenjdk/controls/verify_adoptopenjdk-removal.rb
@@ -1,11 +1,11 @@
-variant = attribute('variant', value: 'openj9', description: 'Variant being used: openj9, openj9-large-heap, or hotspot')
-alternative_bin_cmds = attribute('alternative_bin_cmds',
+variant = input('variant', value: 'openj9', description: 'Variant being used: openj9, openj9-large-heap, or hotspot')
+alternative_bin_cmds = input('alternative_bin_cmds',
                                  value: %w(jar java keytool),
                                  description: 'List of bin commands that should be included in alternatives')
-java_version = attribute('java_version',
+java_version = input('java_version',
                          value: '1.8.0',
                          description: 'Which version of java should be installed')
-java_home = attribute('java_home',
+java_home = input('java_home',
                       value: "/usr/lib/jvm/java-#{java_version.to_i > 8 ? java_version.to_i : java_version.split('.')[1]}-adoptopenjdk-#{variant}",
                       description: 'Path to the Java home directory')
 


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.16.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with test/integration/adoptopenjdk/controls/verify_adoptopenjdk.rb

 - 1:11 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 2:16 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 3:31 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 6:40 convention: `Layout/ClosingParenthesisIndentation` - Indent `)` to column 0 (not 39)
 - 7:22 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 10:21 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 13:30 convention: `Layout/ClosingParenthesisIndentation` - Indent `)` to column 0 (not 29)
 - 14:21 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)

### Issues found and resolved with test/integration/custom-package/controls/verify_home.rb

 - 1:11 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 2:16 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 3:22 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 6:17 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)

### Issues found and resolved with test/integration/remove-adoptopenjdk/controls/verify_adoptopenjdk-removal.rb

 - 1:11 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 2:24 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 5:16 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)
 - 8:13 warning: `InSpec/Deprecations/AttributeHelper` - InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values. (https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper)