### PR TITLE
Remove brew tap --full option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Remove tap_full option as this is no longer supported and there is no replacement
+
 ## 10.1.1 - *2021-10-19*
 
 Standardise files with files in sous-chefs/repo-management

--- a/documentation/resources/adoptopenjdk_install.md
+++ b/documentation/resources/adoptopenjdk_install.md
@@ -25,7 +25,6 @@ Introduced: v7.0.0
 | bin_cmds              | Array             |         | A list of bin_cmds based on the version and variant            |
 | alternatives_priority | Integer           |         | Alternatives priority to set for this Java                     |
 | reset_alternatives    | [true, false]     |         | Whether to reset alternatives before setting                   |
-| tap_full              | [true, false]     | `true`  | Perform a full clone on the tap, as opposed to a shallow clone |
 | tap_url               | String,           |         | The URL of the tap                                             |
 | cask_options          | String,           |         | Options to pass to the brew command during installation        |
 | homebrew_path         | String,           |         | The path to the homebrew binary                                |

--- a/documentation/resources/adoptopenjdk_macos_install.md
+++ b/documentation/resources/adoptopenjdk_macos_install.md
@@ -13,7 +13,6 @@ Introduced: v8.1.0
 
 | Name          | Type              | Default                    | Description                                                    | Allowed Values |
 | ------------- | ----------------- | -------------------------- | -------------------------------------------------------------- |
-| tap_full      | [true, false]     | `true`                     | Perform a full clone on the tap, as opposed to a shallow clone |
 | tap_url       | String            |                            | The URL of the tap                                             |
 | cask_options  | String            |                            | Options to pass to the brew command during installation        |
 | homebrew_path | String            |                            | The path to the homebrew binary                                |

--- a/resources/adoptopenjdk_install.rb
+++ b/resources/adoptopenjdk_install.rb
@@ -18,7 +18,6 @@ property :alternatives_priority, Integer, description: 'Alternatives priority to
 property :reset_alternatives, [true, false], description: 'Whether to reset alternatives before setting'
 
 # MacOS options
-property :tap_full, [true, false], default: true, description: 'Perform a full clone on the tap, as opposed to a shallow clone'
 property :tap_url, String, description: 'The URL of the tap'
 property :cask_options, String, description: 'Options to pass to the brew command during installation'
 property :homebrew_path, String, description: 'The path to the homebrew binary'
@@ -34,7 +33,6 @@ action :install do
               end
 
     adoptopenjdk_macos_install 'homebrew' do
-      tap_full new_resource.tap_full
       tap_url new_resource.tap_url
       cask_options new_resource.cask_options
       homebrew_path new_resource.homebrew_path
@@ -59,7 +57,6 @@ action :remove do
   case node['platform_family']
   when 'mac_os_x'
     adoptopenjdk_macos_install 'homebrew' do
-      tap_full new_resource.tap_full
       tap_url new_resource.tap_url
       cask_options new_resource.cask_options
       homebrew_path new_resource.homebrew_path

--- a/resources/adoptopenjdk_macos_install.rb
+++ b/resources/adoptopenjdk_macos_install.rb
@@ -2,10 +2,6 @@ provides :adoptopenjdk_macos_install
 unified_mode true
 include Java::Cookbook::AdoptOpenJdkMacOsHelpers
 
-property :tap_full, [true, false],
-  default: true,
-  description: 'Perform a full clone on the tap, as opposed to a shallow clone'
-
 property :tap_url, String,
   description: 'The URL of the tap'
 
@@ -40,7 +36,6 @@ property :version, String,
 
 action :install do
   homebrew_tap 'AdoptOpenJDK/openjdk' do
-    full               new_resource.tap_full
     homebrew_path      new_resource.homebrew_path
     owner              new_resource.owner
     url                new_resource.tap_url


### PR DESCRIPTION
# Description

Remove brew tap --full as it is no longer a valid option

## Issues Resolved

MacOS doesn't currently converge. 

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
