### PR TITLE
Add support for amazon corretto 17

### DIFF
--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -19,6 +19,8 @@ module Java
           %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver)
         when '16'
           %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver)
+        when '17'
+          %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver)
         else
           raise 'Corretto version not recognised'
         end
@@ -35,6 +37,8 @@ module Java
             ver = '15.0.2.7.1'
           when '16'
             ver = '16.0.2.7.1'
+          when '17'
+            ver = '17.0.1.12.1'
           else
             raise 'Corretto version not recognised'
           end


### PR DESCRIPTION
This will allow:

```
  corretto_install '17' do
    version "17"
    checksum "2ecc551b54c5bee4535b39703a7dd07629385af13b56acd99eb8c65751c42346"
    full_version full_version_17
    url "https://corretto.aws/downloads/resources/#{full_version_17}/amazon-corretto-#{full_version_17}-linux-x64.tar.gz"
    alternatives_priority 2
    reset_alternatives true
    default false
  end
```
work