### PR TITLE
Resource partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Require Chef 16 for resource partials
+- Add resoruce partials for: MacOS, Linux, Java Home and Common as these are used in a multiple places
+
 ## 10.2.0 - *2022-01-26*
 
 - Remove tap_full option as this is no longer supported and there is no replacement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file is used to list changes made in each version of the Java cookbook.
 ## Unreleased
 
 - Require Chef 16 for resource partials
-- Add resoruce partials for: MacOS, Linux, Java Home and Common as these are used in a multiple places
+- Add resource partials for: MacOS, Linux, Java Home and Common as these are used in a multiple places
 
 ## 10.2.0 - *2022-01-26*
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license           'Apache-2.0'
 description       'Recipes and resources for installing Java and managing certificates'
 source_url        'https://github.com/sous-chefs/java'
 issues_url        'https://github.com/sous-chefs/java/issues'
-chef_version      '>= 15.3'
+chef_version      '>= 16.0'
 version           '10.2.0'
 
 supports 'debian'

--- a/resources/adoptopenjdk_install.rb
+++ b/resources/adoptopenjdk_install.rb
@@ -1,27 +1,30 @@
 provides :adoptopenjdk_install
 unified_mode true
 
-# Common options
-property :version, String, name_property: true, description: 'Java version to install'
+property :variant,
+          String,
+          description: 'Install flavour', default: 'openj9'
 
-# Linux options
-property :variant, String, description: 'Install flavour', default: 'openj9'
-property :url, String, description: 'The URL to download from'
-property :checksum, String, description: 'The checksum for the downloaded file'
-property :java_home, String, description: 'Set to override the java_home'
-property :java_home_mode, String, description: 'The permission for the Java home directory'
-property :java_home_owner, String, description: 'Owner of the Java Home'
-property :java_home_group, String, description: 'Group for the Java Home'
-property :default, [true, false], description: ' Whether to set this as the default Java'
-property :bin_cmds, Array, description: 'A list of bin_cmds based on the version and variant'
-property :alternatives_priority, Integer, description: 'Alternatives priority to set for this Java'
-property :reset_alternatives, [true, false], description: 'Whether to reset alternatives before setting'
+property :url,
+          String,
+          description: 'The URL to download from'
 
-# MacOS options
-property :tap_url, String, description: 'The URL of the tap'
-property :cask_options, String, description: 'Options to pass to the brew command during installation'
-property :homebrew_path, String, description: 'The path to the homebrew binary'
-property :owner, [String, Integer], description: 'The owner of the Homebrew installation'
+property :checksum,
+          String,
+          description: 'The checksum for the downloaded file'
+
+property :java_home,
+          String,
+          description: 'Set to override the java_home'
+
+property :bin_cmds,
+          Array,
+          description: 'A list of bin_cmds based on the version and variant'
+
+use 'partial/_common'
+use 'partial/_linux'
+use 'partial/_java_home'
+use 'partial/_macos'
 
 action :install do
   case node['platform_family']

--- a/resources/adoptopenjdk_linux_install.rb
+++ b/resources/adoptopenjdk_linux_install.rb
@@ -2,52 +2,31 @@ provides :adoptopenjdk_linux_install
 unified_mode true
 include Java::Cookbook::AdoptOpenJdkHelpers
 
-property :version, String, name_property: true, description: 'Java version to install'
-
 property :variant, String,
-  equal_to: %w(hotspot openj9 openj9-large-heap),
-  default: 'openj9',
-  description: 'Install flavour'
+          equal_to: %w(hotspot openj9 openj9-large-heap),
+          default: 'openj9',
+          description: 'Install flavour'
 
 property :url, String,
-  default: lazy { default_adopt_openjdk_url(version)[variant] },
-  description: 'The URL to download from'
+          default: lazy { default_adopt_openjdk_url(version)[variant] },
+          description: 'The URL to download from'
 
 property :checksum, String,
-  regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
-  default: lazy { default_adopt_openjdk_checksum(version)[variant] },
-  description: 'The checksum for the downloaded file'
+          regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
+          default: lazy { default_adopt_openjdk_checksum(version)[variant] },
+          description: 'The checksum for the downloaded file'
 
 property :java_home, String,
-  default: lazy { "/usr/lib/jvm/java-#{version}-adoptopenjdk-#{variant}/#{sub_dir(url)}" },
-  description: 'Set to override the java_home'
-
-property :java_home_mode, String,
-  description: 'The permission for the Java home directory'
-
-property :java_home_owner, String,
-  default: 'root',
-  description: 'Owner of the Java Home'
-
-property :java_home_group, String,
-  default: lazy { node['root_group'] },
-  description: 'Group for the Java Home'
-
-property :default, [true, false],
-  default: true,
-  description: ' Whether to set this as the defalut Java'
+          default: lazy { "/usr/lib/jvm/java-#{version}-adoptopenjdk-#{variant}/#{sub_dir(url)}" },
+          description: 'Set to override the java_home'
 
 property :bin_cmds, Array,
-  default: lazy { default_adopt_openjdk_bin_cmds(version)[variant] },
-  description: 'A list of bin_cmds based on the version and variant'
+          default: lazy { default_adopt_openjdk_bin_cmds(version)[variant] },
+          description: 'A list of bin_cmds based on the version and variant'
 
-property :alternatives_priority, Integer,
-  default: 1,
-  description: 'Alternatives priority to set for this Java'
-
-property :reset_alternatives, [true, false],
-  default: true,
-  description: 'Whether to reset alternatives before setting'
+use 'partial/_common'
+use 'partial/_linux'
+use 'partial/_java_home'
 
 action :install do
   extract_dir = new_resource.java_home.split('/')[0..-2].join('/')

--- a/resources/adoptopenjdk_macos_install.rb
+++ b/resources/adoptopenjdk_macos_install.rb
@@ -2,37 +2,27 @@ provides :adoptopenjdk_macos_install
 unified_mode true
 include Java::Cookbook::AdoptOpenJdkMacOsHelpers
 
-property :tap_url, String,
-  description: 'The URL of the tap'
-
-property :cask_options, String,
-  description: 'Options to pass to the brew command during installation'
-
-property :homebrew_path, String,
-  description: 'The path to the homebrew binary'
-
-property :owner, [String, Integer],
-  description: 'The owner of the Homebrew installation'
+use 'partial/_macos'
 
 property :java_home, String,
-  default: lazy { macos_java_home(version) },
-  description: 'MacOS specific JAVA_HOME'
+          default: lazy { macos_java_home(version) },
+          description: 'MacOS specific JAVA_HOME'
 
 property :version, String,
-  default: 'adoptopenjdk14',
-  equal_to: %w(
-    adoptopenjdk8 adoptopenjdk8-openj9 adoptopenjdk8-openj9-large
-    adoptopenjdk8-jre adoptopenjdk8-openj9-jre adoptopenjdk8-jre-large
-    adoptopenjdk9 adoptopenjdk10
-    adoptopenjdk11 adoptopenjdk11-openj9 adoptopenjdk11-openj9-large
-    adoptopenjdk11-jre adoptopenjdk11-openj9-jre adoptopenjdk11-openj9-jre-large
-    adoptopenjdk12 adoptopenjdk12-openj9 adoptopenjdk12-openj9-large
-    adoptopenjdk12-jre adoptopenjdk12-openj9-jre adoptopenjdk12-openj9-jre-large
-    adoptopenjdk13 adoptopenjdk13-openj9 adoptopenjdk13-openj9-large
-    adoptopenjdk13-jre adoptopenjdk13-openj9-jre adoptopenjdk13-openj9-jre-large
-    adoptopenjdk14 adoptopenjdk14-openj9 adoptopenjdk14-openj9-large
-    adoptopenjdk14-jre adoptopenjdk14-openj9-jre adoptopenjdk14-openj9-jre-large
-  )
+          default: 'adoptopenjdk14',
+          equal_to: %w(
+            adoptopenjdk8 adoptopenjdk8-openj9 adoptopenjdk8-openj9-large
+            adoptopenjdk8-jre adoptopenjdk8-openj9-jre adoptopenjdk8-jre-large
+            adoptopenjdk9 adoptopenjdk10
+            adoptopenjdk11 adoptopenjdk11-openj9 adoptopenjdk11-openj9-large
+            adoptopenjdk11-jre adoptopenjdk11-openj9-jre adoptopenjdk11-openj9-jre-large
+            adoptopenjdk12 adoptopenjdk12-openj9 adoptopenjdk12-openj9-large
+            adoptopenjdk12-jre adoptopenjdk12-openj9-jre adoptopenjdk12-openj9-jre-large
+            adoptopenjdk13 adoptopenjdk13-openj9 adoptopenjdk13-openj9-large
+            adoptopenjdk13-jre adoptopenjdk13-openj9-jre adoptopenjdk13-openj9-jre-large
+            adoptopenjdk14 adoptopenjdk14-openj9 adoptopenjdk14-openj9-large
+            adoptopenjdk14-jre adoptopenjdk14-openj9-jre adoptopenjdk14-openj9-jre-large
+          )
 
 action :install do
   homebrew_tap 'AdoptOpenJDK/openjdk' do

--- a/resources/alternatives.rb
+++ b/resources/alternatives.rb
@@ -1,22 +1,27 @@
 unified_mode true
 
-property :java_location, String,
-  description: 'Java installation location'
+property :java_location,
+          String,
+          description: 'Java installation location'
 
-property :bin_cmds, Array,
-  description: 'Array of Java tool names to set or unset alternatives on'
+property :bin_cmds,
+          Array,
+          description: 'Array of Java tool names to set or unset alternatives on'
 
-property :default, [true, false],
-  default: true,
-  description: 'Whether to set the Java tools as system default. Boolean, defaults to `true`'
+property :default,
+          [true, false],
+          default: true,
+          description: 'Whether to set the Java tools as system default. Boolean, defaults to `true`'
 
-property :priority, Integer,
-  default: 1061,
-  description: ' Priority of the alternatives. Integer, defaults to `1061`'
+property :priority,
+          Integer,
+          default: 1061,
+          description: ' Priority of the alternatives. Integer, defaults to `1061`'
 
-property :reset_alternatives, [true, false],
-  default: true,
-  description: 'Whether to reset alternatives before setting them'
+property :reset_alternatives,
+          [true, false],
+          default: true,
+          description: 'Whether to reset alternatives before setting them'
 
 action :set do
   if new_resource.bin_cmds

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -1,46 +1,57 @@
 unified_mode true
 include Java::Cookbook::CertificateHelpers
 
-property :cert_alias, String,
-  name_property: true,
-  description: 'The alias of the certificate in the keystore. This defaults to the name of the resource'
+property :cert_alias,
+          String,
+          name_property: true,
+          description: 'The alias of the certificate in the keystore. This defaults to the name of the resource'
 
-property :java_home, String,
-  default: lazy { node['java']['java_home'] },
-  description: 'The java home directory'
+property :java_home,
+          String,
+          default: lazy { node['java']['java_home'] },
+          description: 'The java home directory'
 
-property :java_version, String,
-  default: lazy { node['java']['jdk_version'] },
-  description: 'The major java version'
+property :java_version,
+          String,
+          default: lazy { node['java']['jdk_version'] },
+          description: 'The major java version'
 
-property :cacerts, [true, false],
-  default: true,
-  description: 'Specify true for interacting with the Java installation cacerts file. (Java 9+)'
+property :cacerts,
+          [true, false],
+          default: true,
+          description: 'Specify true for interacting with the Java installation cacerts file. (Java 9+)'
 
-property :keystore_path, String,
-  default: lazy { default_truststore_path(java_version, java_home) },
-  description: 'Path to the keystore'
+property :keystore_path,
+          String,
+          default: lazy { default_truststore_path(java_version, java_home) },
+          description: 'Path to the keystore'
 
-property :keystore_passwd, String,
-  default: 'changeit',
-  description: 'Password to the keystore'
+property :keystore_passwd,
+          String,
+          default: 'changeit',
+          description: 'Password to the keystore'
 
-property :cert_data, String,
-  description: 'The certificate data to install'
+property :cert_data,
+          String,
+          description: 'The certificate data to install'
 
-property :cert_file, String,
-  description: 'Path to a certificate file to install'
+property :cert_file,
+          String,
+          description: 'Path to a certificate file to install'
 
-property :ssl_endpoint, String,
-  description: 'An SSL end-point from which to download the certificate'
+property :ssl_endpoint,
+          String,
+          description: 'An SSL end-point from which to download the certificate'
 
-property :starttls, String,
-  equal_to: %w(smtp pop3 imap ftp xmpp xmpp-server irc postgres mysql lmtp nntp sieve ldap),
-  description: 'A protocol specific STARTTLS argument to use when fetching from an ssl_endpoint'
+property :starttls,
+          String,
+          equal_to: %w(smtp pop3 imap ftp xmpp xmpp-server irc postgres mysql lmtp nntp sieve ldap),
+          description: 'A protocol specific STARTTLS argument to use when fetching from an ssl_endpoint'
 
-property :file_cache_path, String,
-  default: Chef::Config[:file_cache_path],
-  description: 'Location to store certificate files'
+property :file_cache_path,
+          String,
+          default: Chef::Config[:file_cache_path],
+          description: 'Location to store certificate files'
 
 action :install do
   require 'openssl'

--- a/resources/corretto_install.rb
+++ b/resources/corretto_install.rb
@@ -2,49 +2,28 @@ provides :corretto_install
 unified_mode true
 include Java::Cookbook::CorrettoHelpers
 
-property :version, String, name_property: true, description: 'Java version to install'
 property :full_version, String,
-  description: 'Used to configure the package directory, change this is the version installed by the package is no longer correct'
+          description: 'Used to configure the package directory, change this is the version installed by the package is no longer correct'
 
 property :url, String,
-  default: lazy { default_corretto_url(version) },
-  description: 'The URL to download from'
+          default: lazy { default_corretto_url(version) },
+          description: 'The URL to download from'
 
 property :checksum, String,
-  regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
-  description: 'The checksum for the downloaded file'
+          regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
+          description: 'The checksum for the downloaded file'
 
 property :java_home, String,
-  default: lazy { "/usr/lib/jvm/java-#{version}-corretto/#{corretto_sub_dir(version, full_version)}" },
-  description: 'Set to override the java_home'
-
-property :java_home_mode, String,
-  default: '0755',
-  description: 'The permission for the Java home directory'
-
-property :java_home_owner, String,
-  default: 'root',
-  description: 'Owner of the Java Home'
-
-property :java_home_group, String,
-  default: lazy { node['root_group'] },
-  description: 'Group for the Java Home'
-
-property :default, [true, false],
-  default: true,
-  description: ' Whether to set this as the defalut Java'
+          default: lazy { "/usr/lib/jvm/java-#{version}-corretto/#{corretto_sub_dir(version, full_version)}" },
+          description: 'Set to override the java_home'
 
 property :bin_cmds, Array,
-  default: lazy { default_corretto_bin_cmds(version) },
-  description: 'A list of bin_cmds based on the version and variant'
+          default: lazy { default_corretto_bin_cmds(version) },
+          description: 'A list of bin_cmds based on the version and variant'
 
-property :alternatives_priority, Integer,
-  default: 1,
-  description: 'Alternatives priority to set for this Java'
-
-property :reset_alternatives, [true, false],
-  default: true,
-  description: 'Whether to reset alternatives before setting'
+use 'partial/_common'
+use 'partial/_linux'
+use 'partial/_java_home'
 
 action :install do
   extract_dir = new_resource.java_home.split('/')[0..-2].join('/')

--- a/resources/jce.rb
+++ b/resources/jce.rb
@@ -1,12 +1,32 @@
 unified_mode true
 
-property :jdk_version, String, default: lazy { node['java']['jdk_version'].to_s }, description: 'The Java version to install into'
-property :jce_url, String, default: lazy { node['java']['oracle']['jce'][jdk_version]['url'] }, description: 'The URL for the JCE distribution'
-property :jce_checksum, String, default: lazy { node['java']['oracle']['jce'][jdk_version]['checksum'] }, description: 'The checksum of the JCE distribution'
-property :java_home, String, default: lazy { node['java']['java_home'] }, description: 'The location of the Java installation'
-property :jce_home, String, default: lazy { node['java']['oracle']['jce']['home'] }, description: 'The location where JCE files will be decompressed for installation'
-property :jce_cookie, String, default: lazy { node['java']['oracle']['accept_oracle_download_terms'] ? 'oraclelicense=accept-securebackup-cookie' : '' }, description: 'Indicates that you accept Oracles EULA'
-property :principal, String, default: lazy { platform_family?('windows') ? node['java']['windows']['owner'] : 'administrator' }, description: 'For Windows installations only, this determines the owner of the JCE files'
+property :jdk_version,
+          String,
+          default: lazy { node['java']['jdk_version'].to_s }, description: 'The Java version to install into'
+
+property :jce_url,
+          String,
+          default: lazy { node['java']['oracle']['jce'][jdk_version]['url'] }, description: 'The URL for the JCE distribution'
+
+property :jce_checksum,
+          String,
+          default: lazy { node['java']['oracle']['jce'][jdk_version]['checksum'] }, description: 'The checksum of the JCE distribution'
+
+property :java_home,
+          String,
+          default: lazy { node['java']['java_home'] }, description: 'The location of the Java installation'
+
+property :jce_home,
+          String,
+          default: lazy { node['java']['oracle']['jce']['home'] }, description: 'The location where JCE files will be decompressed for installation'
+
+property :jce_cookie,
+          String,
+          default: lazy { node['java']['oracle']['accept_oracle_download_terms'] ? 'oraclelicense=accept-securebackup-cookie' : '' }, description: 'Indicates that you accept Oracles EULA'
+
+property :principal,
+          String,
+          default: lazy { platform_family?('windows') ? node['java']['windows']['owner'] : 'administrator' }, description: 'For Windows installations only, this determines the owner of the JCE files'
 
 action :install do
   jdk_version = new_resource.jdk_version

--- a/resources/openjdk_install.rb
+++ b/resources/openjdk_install.rb
@@ -2,23 +2,39 @@ provides :openjdk_install
 unified_mode true
 include Java::Cookbook::OpenJdkHelpers
 
-property :version, String, name_property: true, description: 'Java major version to install'
-property :install_type, String,
-  default: lazy { default_openjdk_install_method(version) },
-  equal_to: %w( package source ),
-  description: 'Installation type'
-property :pkg_names, [String, Array], description: 'List of packages to install'
-property :pkg_version, String, description: 'Package version to install'
-property :java_home, String, description: 'Set to override the java_home'
-property :default, [true, false], description: ' Whether to set this as the defalut Java'
-property :bin_cmds, Array, description: 'A list of bin_cmds based on the version and variant'
-property :alternatives_priority, Integer, description: 'Alternatives priority to set for this Java'
-property :reset_alternatives, [true, false], description: 'Whether to reset alternatives before setting'
-property :url, String, description: 'The URL to download from'
-property :checksum, String, description: 'The checksum for the downloaded file'
-property :java_home_mode, String,  description: 'The permission for the Java home directory'
-property :java_home_owner, String, description: 'Owner of the Java Home'
-property :java_home_group, String, description: 'Group for the Java Home'
+property :install_type,
+          String,
+          default: lazy { default_openjdk_install_method(version) },
+          equal_to: %w( package source ),
+          description: 'Installation type'
+
+property :pkg_names,
+          [String, Array],
+          description: 'List of packages to install'
+
+property :pkg_version,
+          String,
+          description: 'Package version to install'
+
+property :java_home,
+          String,
+          description: 'Set to override the java_home'
+
+property :bin_cmds,
+          Array,
+          description: 'A list of bin_cmds based on the version and variant'
+
+property :url,
+          String,
+          description: 'The URL to download from'
+
+property :checksum,
+          String,
+          description: 'The checksum for the downloaded file'
+
+use 'partial/_common'
+use 'partial/_linux'
+use 'partial/_java_home'
 
 action :install do
   if new_resource.install_type == 'package'

--- a/resources/openjdk_pkg_install.rb
+++ b/resources/openjdk_pkg_install.rb
@@ -2,36 +2,27 @@ provides :openjdk_pkg_install
 unified_mode true
 include Java::Cookbook::OpenJdkHelpers
 
-property :version, String,
-  name_property: true,
-  description: 'Java major version to install'
-
 property :pkg_names, [String, Array],
-  default: lazy { default_openjdk_pkg_names(version) },
-  description: 'List of packages to install'
+          default: lazy { default_openjdk_pkg_names(version) },
+          description: 'List of packages to install'
 
 property :pkg_version, String,
-  description: 'Package version to install'
+          description: 'Package version to install'
 
 property :java_home, String,
-  default: lazy { default_openjdk_pkg_java_home(version) },
-  description: 'Set to override the java_home'
-
-property :default, [true, false],
-  default: true,
-  description: ' Whether to set this as the defalut Java'
+          default: lazy { default_openjdk_pkg_java_home(version) },
+          description: 'Set to override the java_home'
 
 property :bin_cmds, Array,
-  default: lazy { default_openjdk_bin_cmds(version) },
-  description: 'A list of bin_cmds based on the version and variant'
+          default: lazy { default_openjdk_bin_cmds(version) },
+          description: 'A list of bin_cmds based on the version and variant'
 
 property :alternatives_priority, Integer,
-  default: 1062,
-  description: 'Alternatives priority to set for this Java'
+          default: 1062,
+          description: 'Alternatives priority to set for this Java'
 
-property :reset_alternatives, [true, false],
-  default: true,
-  description: 'Whether to reset alternatives before setting'
+use 'partial/_common'
+use 'partial/_linux'
 
 action :install do
   if platform?('ubuntu')

--- a/resources/openjdk_source_install.rb
+++ b/resources/openjdk_source_install.rb
@@ -3,49 +3,29 @@ unified_mode true
 include Java::Cookbook::OpenJdkHelpers
 
 property :version, String,
-  name_property: true,
-  description: 'Java version to install'
+          name_property: true,
+          description: 'Java version to install'
 
 property :url, String,
-  default: lazy { default_openjdk_url(version) },
-  description: 'The URL to download from'
+          default: lazy { default_openjdk_url(version) },
+          description: 'The URL to download from'
 
 property :checksum, String,
-  regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
-  default: lazy { default_openjdk_checksum(version) },
-  description: 'The checksum for the downloaded file'
+          regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/,
+          default: lazy { default_openjdk_checksum(version) },
+          description: 'The checksum for the downloaded file'
 
 property :java_home, String,
-  default: lazy { "/usr/lib/jvm/java-#{version}-openjdk/jdk-#{version}" },
-  description: 'Set to override the java_home'
-
-property :java_home_mode, String,
-  default: '0755',
-  description: 'The permission for the Java home directory'
-
-property :java_home_owner, String,
-  default: 'root',
-  description: 'Owner of the Java Home'
-
-property :java_home_group, String,
-  default: lazy { node['root_group'] },
-  description: 'Group for the Java Home'
-
-property :default, [true, false],
-  default: true,
-  description: ' Whether to set this as the defalut Java'
+          default: lazy { "/usr/lib/jvm/java-#{version}-openjdk/jdk-#{version}" },
+          description: 'Set to override the java_home'
 
 property :bin_cmds, Array,
-  default: lazy { default_openjdk_bin_cmds(version) },
-  description: 'A list of bin_cmds based on the version and variant'
+          default: lazy { default_openjdk_bin_cmds(version) },
+          description: 'A list of bin_cmds based on the version and variant'
 
-property :alternatives_priority, Integer,
-  default: 1,
-  description: 'Alternatives priority to set for this Java'
-
-property :reset_alternatives, [true, false],
-  default: true,
-  description: 'Whether to reset alternatives before setting'
+use 'partial/_common'
+use 'partial/_linux'
+use 'partial/_java_home'
 
 action :install do
   extract_dir = new_resource.java_home.split('/')[0..-2].join('/')

--- a/resources/partial/_common.rb
+++ b/resources/partial/_common.rb
@@ -1,0 +1,3 @@
+property :version, String,
+          name_property: true,
+          description: 'Java version to install'

--- a/resources/partial/_java_home.rb
+++ b/resources/partial/_java_home.rb
@@ -1,0 +1,11 @@
+property :java_home_mode, String,
+          default: '0755',
+          description: 'The permission for the Java home directory'
+
+property :java_home_owner, String,
+          default: 'root',
+          description: 'Owner of the Java Home'
+
+property :java_home_group, String,
+          default: lazy { node['root_group'] },
+          description: 'Group for the Java Home'

--- a/resources/partial/_linux.rb
+++ b/resources/partial/_linux.rb
@@ -1,0 +1,11 @@
+property :alternatives_priority, Integer,
+        default: 1,
+        description: 'Alternatives priority to set for this Java'
+
+property :reset_alternatives, [true, false],
+        default: true,
+        description: 'Whether to reset alternatives before setting'
+
+property :default, [true, false],
+        default: true,
+        description: ' Whether to set this as the defalut Java'

--- a/resources/partial/_linux.rb
+++ b/resources/partial/_linux.rb
@@ -8,4 +8,4 @@ property :reset_alternatives, [true, false],
 
 property :default, [true, false],
         default: true,
-        description: ' Whether to set this as the defalut Java'
+        description: ' Whether to set this as the default Java'

--- a/resources/partial/_macos.rb
+++ b/resources/partial/_macos.rb
@@ -1,0 +1,15 @@
+property :tap_url,
+        String,
+        description: 'The URL of the tap'
+
+property :cask_options,
+        String,
+        description: 'Options to pass to the brew command during installation'
+
+property :homebrew_path,
+        String,
+        description: 'The path to the homebrew binary'
+
+property :owner,
+        [String, Integer],
+        description: 'The owner of the Homebrew installation'


### PR DESCRIPTION
# Description

- Require Chef 16 for resource partials
- Add resource partials for: MacOS, Linux, Java Home and Common as these are used in a multiple places

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
