### PR TITLE
Add Cookstyle back into the required checks

### DIFF
--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -8,7 +8,7 @@ name: 'Test'
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.1
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.2
 
   integration:
     needs: 'lint-unit'

--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -8,7 +8,7 @@ name: 'Test'
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
     needs: 'lint-unit'


### PR DESCRIPTION
# Description

Add Cookstyle back into the required checks

## Issues Resolved

Cookstyle doesn't actually run in 0.0.1 of the check

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
