### PR TITLE
Update Corretto URLs

### DIFF
--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -44,8 +44,8 @@ jobs:
           - adoptopenjdk-removal-11-openj9
           - corretto-8
           - corretto-11
-          - corretto-15
-          - corretto-16
+          - corretto-17
+          - corretto-18
           - custom-package-8
           - custom-package-11
           - custom-package-11-openj9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Remove Correto 15 and 16
+- Add Corretto 17 and 18
+- Change the defualt download URL for Corretto to the versioned resources URL, rather than latest.
+
 ## 11.0.2 - *2022-04-20*
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 11.0.1 - *2022-02-16*
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -166,20 +166,20 @@ suites:
     verifier:
       inspec_tests: [test/integration/corretto]
       inputs: {java_version: "11"}
-  - name: corretto-15
+  - name: corretto-17
     run_list:
       - recipe[test::corretto]
-    attributes: {version: "15"}
+    attributes: {version: "17"}
     verifier:
       inspec_tests: [test/integration/corretto]
-      inputs: {java_version: "15"}
-  - name: corretto-16
+      inputs: {java_version: "17"}
+  - name: corretto-18
     run_list:
       - recipe[test::corretto]
-    attributes: {version: "16"}
+    attributes: {version: "18"}
     verifier:
       inspec_tests: [test/integration/corretto]
-      inputs: {java_version: "16"}
+      inputs: {java_version: "18"}
 
   # Custom URL tests
   - name: custom-package-8

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -6,7 +6,7 @@ module Java
       end
 
       def default_corretto_url(version)
-        "https://corretto.aws/downloads/latest/amazon-corretto-#{version}-#{corretto_arch}-linux-jdk.tar.gz"
+        "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-linux-#{corretto_arch}.tar.gz"
       end
 
       def default_corretto_bin_cmds(version)
@@ -15,9 +15,7 @@ module Java
           %w(appletviewer clhsdb extcheck hsdb idlj jar jarsigner java java-rmi.cgi javac javadoc javafxpackager javah javap javapackager jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
         when '11'
           %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
-        when '15'
-          %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver)
-        when '16'
+        when '15', '17', '18'
           %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver)
         else
           raise 'Corretto version not recognised'
@@ -28,13 +26,13 @@ module Java
         if full_version.nil?
           case version
           when '8'
-            ver = '8.302.08.1'
+            ver = '8.332.08.1'
           when '11'
-            ver = '11.0.12.7.1'
-          when '15'
-            ver = '15.0.2.7.1'
-          when '16'
-            ver = '16.0.2.7.1'
+            ver = '11.0.15.9.1'
+          when '17'
+            ver = '17.0.3.6.1'
+          when '18'
+            ver = '18.0.1.10.1'
           else
             raise 'Corretto version not recognised'
           end

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -5,10 +5,6 @@ module Java
         node['kernel']['machine'].match?('aarch64') ? 'aarch64' : 'x64'
       end
 
-      def default_corretto_url(version)
-        "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-linux-#{corretto_arch}.tar.gz"
-      end
-
       def default_corretto_bin_cmds(version)
         case version.to_s
         when '8'
@@ -22,25 +18,34 @@ module Java
         end
       end
 
-      def corretto_sub_dir(version, full_version = nil)
+      def default_corretto_minor(version)
         if full_version.nil?
           case version
           when '8'
-            ver = '8.332.08.1'
+            '8.332.08.1'
           when '11'
-            ver = '11.0.15.9.1'
+            '11.0.15.9.1'
           when '17'
-            ver = '17.0.3.6.1'
+            '17.0.3.6.1'
           when '18'
-            ver = '18.0.1.10.1'
+            '18.0.1.10.1'
           else
             raise 'Corretto version not recognised'
           end
         else
-          ver = full_version
+          full_version
         end
+      end
 
+      def corretto_sub_dir(version, full_version = nil)
+        ver = full_version.nil? ? default_corretto_minor(version) : full_version
         "amazon-corretto-#{ver}-linux-#{corretto_arch}"
+      end
+
+      def default_corretto_url(version)
+        ver = version.include?('.') ? version : default_corretto_minor(version)
+
+        "https://corretto.aws/downloads/resources/#{ver}/amazon-corretto-#{ver}-linux-#{corretto_arch}.tar.gz"
       end
     end
   end

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -18,22 +18,18 @@ module Java
         end
       end
 
-      def default_corretto_minor(version, full_version = nil)
-        if full_version.nil?
-          case version
-          when '8'
-            '8.332.08.1'
-          when '11'
-            '11.0.15.9.1'
-          when '17'
-            '17.0.3.6.1'
-          when '18'
-            '18.0.1.10.1'
-          else
-            raise 'Corretto version not recognised'
-          end
+      def default_corretto_minor(version)
+        case version
+        when '8'
+          '8.332.08.1'
+        when '11'
+          '11.0.15.9.1'
+        when '17'
+          '17.0.3.6.1'
+        when '18'
+          '18.0.1.10.1'
         else
-          full_version
+          raise 'Corretto version not recognised'
         end
       end
 

--- a/libraries/corretto_helpers.rb
+++ b/libraries/corretto_helpers.rb
@@ -18,7 +18,7 @@ module Java
         end
       end
 
-      def default_corretto_minor(version)
+      def default_corretto_minor(version, full_version = nil)
         if full_version.nil?
           case version
           when '8'

--- a/spec/libraries/corretto_helpers_spec.rb
+++ b/spec/libraries/corretto_helpers_spec.rb
@@ -31,21 +31,21 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       end
     end
 
-    context 'Corretto 15 x64' do
-      let(:version) { '15' }
+    context 'Corretto 17 x64' do
+      let(:version) { '17' }
       let(:machine) { 'x86_64' }
 
       it 'returns the correct URL' do
-        expect(subject.default_corretto_url(version)).to match /corretto-15.+\.tar.gz/
+        expect(subject.default_corretto_url(version)).to match /corretto-17.+\.tar.gz/
       end
     end
 
-    context 'Corretto 16 x64' do
-      let(:version) { '16' }
+    context 'Corretto 18 x64' do
+      let(:version) { '18' }
       let(:machine) { 'x86_64' }
 
       it 'returns the correct URL' do
-        expect(subject.default_corretto_url(version)).to match /corretto-16.+\.tar.gz/
+        expect(subject.default_corretto_url(version)).to match /corretto-18.+\.tar.gz/
       end
     end
 
@@ -67,21 +67,21 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       end
     end
 
-    context 'Corretto 15 aarch64' do
-      let(:version) { '15' }
+    context 'Corretto 17 aarch64' do
+      let(:version) { '17' }
       let(:machine) { 'aarch64' }
 
       it 'returns the correct URL' do
-        expect(subject.default_corretto_url(version)).to match /corretto-15.+\.tar.gz/
+        expect(subject.default_corretto_url(version)).to match /corretto-17.+\.tar.gz/
       end
     end
 
-    context 'Corretto 16 aarch64' do
-      let(:version) { '16' }
+    context 'Corretto 18 aarch64' do
+      let(:version) { '18' }
       let(:machine) { 'aarch64' }
 
       it 'returns the correct URL' do
-        expect(subject.default_corretto_url(version)).to match /corretto-16.+\.tar.gz/
+        expect(subject.default_corretto_url(version)).to match /corretto-18.+\.tar.gz/
       end
     end
   end
@@ -109,120 +109,120 @@ RSpec.describe Java::Cookbook::CorrettoHelpers do
       end
     end
 
-    context 'Corretto 15' do
-      let(:version) { '15' }
+    context 'Corretto 17' do
+      let(:version) { '17' }
 
       it 'returns the correct bin command array' do
-        expect(subject.default_corretto_bin_cmds(version)).to_not include 'unpack200'
+        expect(subject.default_corretto_bin_cmds(version)).to_not include 'jjs'
         expect(subject.default_corretto_bin_cmds(version)).to include 'jaotc'
       end
     end
 
-    context 'Corretto 16' do
-      let(:version) { '16' }
+    context 'Corretto 18' do
+      let(:version) { '18' }
 
       it 'returns the correct bin command array' do
-        expect(subject.default_corretto_bin_cmds(version)).to_not include 'unpack200'
+        expect(subject.default_corretto_bin_cmds(version)).to_not include 'jjs'
         expect(subject.default_corretto_bin_cmds(version)).to include 'jaotc'
       end
     end
-  end
 
-  describe '#corretto_sub_dir' do
-    before do
-      allow(subject).to receive(:[]).with('version', 'full_version').and_return(version)
-      allow(subject).to receive(:[]).with('kernel').and_return('machine' => machine)
-    end
-
-    context 'No full_version passed for Corretto 8 x64' do
-      let(:version) { '8' }
-      let(:machine) { 'x86_64' }
-
-      it 'returns the default directory value for Corrretto 8 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '8.302.08.1'
+    describe '#corretto_sub_dir' do
+      before do
+        allow(subject).to receive(:[]).with('version', 'full_version').and_return(version)
+        allow(subject).to receive(:[]).with('kernel').and_return('machine' => machine)
       end
-    end
 
-    context 'No full_version passed for Corretto 8 aarch64' do
-      let(:version) { '8' }
-      let(:machine) { 'aarch64' }
+      context 'No full_version passed for Corretto 8 x64' do
+        let(:version) { '8' }
+        let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 8 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '8.302.08.1'
+        it 'returns the default directory value for Corrretto 8 x64' do
+          expect(subject.corretto_sub_dir(version)).to include '8.332.08.1'
+        end
       end
-    end
 
-    context 'No full_version passed for Corretto 11 x64' do
-      let(:version) { '11' }
-      let(:machine) { 'x86_64' }
+      context 'No full_version passed for Corretto 8 aarch64' do
+        let(:version) { '8' }
+        let(:machine) { 'aarch64' }
 
-      it 'returns the default directory value for Corrretto 11 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '11.0.12.7.1'
+        it 'returns the default directory value for Corrretto 8 aarch64' do
+          expect(subject.corretto_sub_dir(version)).to include '8.332.08.1'
+        end
       end
-    end
 
-    context 'No full_version passed for Corretto 11 aarch64' do
-      let(:version) { '11' }
-      let(:machine) { 'aarch64' }
+      context 'No full_version passed for Corretto 11 x64' do
+        let(:version) { '11' }
+        let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 11 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '11.0.12.7.1'
+        it 'returns the default directory value for Corrretto 11 x64' do
+          expect(subject.corretto_sub_dir(version)).to include '11.0.15.9.1'
+        end
       end
-    end
 
-    context 'No full_version passed for Corretto 15 x64' do
-      let(:version) { '15' }
-      let(:machine) { 'x86_64' }
+      context 'No full_version passed for Corretto 11 aarch64' do
+        let(:version) { '11' }
+        let(:machine) { 'aarch64' }
 
-      it 'returns the default directory value for Corrretto 15 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '15.0.2.7.1'
+        it 'returns the default directory value for Corrretto 11 aarch64' do
+          expect(subject.corretto_sub_dir(version)).to include '11.0.15.9.1'
+        end
       end
-    end
 
-    context 'No full_version passed for Corretto 15 aarch64' do
-      let(:version) { '15' }
-      let(:machine) { 'aarch64' }
+      context 'No full_version passed for Corretto 17 x64' do
+        let(:version) { '17' }
+        let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 15 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '15.0.2.7.1'
+        it 'returns the default directory value for Corrretto 17 x64' do
+          expect(subject.corretto_sub_dir(version)).to include '17.0.3.6.1'
+        end
       end
-    end
 
-    context 'No full_version passed for Corretto 16 x64' do
-      let(:version) { '16' }
-      let(:machine) { 'x86_64' }
+      context 'No full_version passed for Corretto 17 aarch64' do
+        let(:version) { '17' }
+        let(:machine) { 'aarch64' }
 
-      it 'returns the default directory value for Corrretto 16 x64' do
-        expect(subject.corretto_sub_dir(version)).to include '16.0.2.7.1'
+        it 'returns the default directory value for Corrretto 17 aarch64' do
+          expect(subject.corretto_sub_dir(version)).to include '17.0.3.6.1'
+        end
       end
-    end
 
-    context 'No full_version passed for Corretto 16 aarch64' do
-      let(:version) { '16' }
-      let(:machine) { 'aarch64' }
+      context 'No full_version passed for Corretto 18 x64' do
+        let(:version) { '18' }
+        let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 16 aarch64' do
-        expect(subject.corretto_sub_dir(version)).to include '16.0.2.7.1'
+        it 'returns the default directory value for Corrretto 18 x64' do
+          expect(subject.corretto_sub_dir(version)).to include '18.0.1.10.1'
+        end
       end
-    end
 
-    context 'A full version passed for for Corretto 8 x64' do
-      let(:version) { '8' }
-      let(:full_version) { '8.123.45.6' }
-      let(:machine) { 'x86_64' }
+      context 'No full_version passed for Corretto 18 aarch64' do
+        let(:version) { '18' }
+        let(:machine) { 'aarch64' }
 
-      it 'returns the default directory value for Corrretto 8 x64' do
-        expect(subject.corretto_sub_dir(version, full_version)).to include '8.123.45.6'
+        it 'returns the default directory value for Corrretto 18 aarch64' do
+          expect(subject.corretto_sub_dir(version)).to include '18.0.1.10.1'
+        end
       end
-    end
 
-    context 'A full version passed for for Corretto 8 aarch64' do
-      let(:version) { '8' }
-      let(:full_version) { '8.123.45.6' }
-      let(:machine) { 'aarch64' }
+      context 'A full version passed for for Corretto 8 x64' do
+        let(:version) { '8' }
+        let(:full_version) { '8.123.45.6' }
+        let(:machine) { 'x86_64' }
 
-      it 'returns the default directory value for Corrretto 8 aarch64' do
-        expect(subject.corretto_sub_dir(version, full_version)).to include '8.123.45.6'
+        it 'returns the default directory value for Corrretto 8 x64' do
+          expect(subject.corretto_sub_dir(version, full_version)).to include '8.123.45.6'
+        end
+      end
+
+      context 'A full version passed for for Corretto 8 aarch64' do
+        let(:version) { '8' }
+        let(:full_version) { '8.123.45.6' }
+        let(:machine) { 'aarch64' }
+
+        it 'returns the default directory value for Corrretto 8 aarch64' do
+          expect(subject.corretto_sub_dir(version, full_version)).to include '8.123.45.6'
+        end
       end
     end
   end


### PR DESCRIPTION
# Description

- Remove Correto 15 and 16
- Add Corretto 17 and 18
- Change the default download URL for Corretto to the versioned resources URL, rather than the latest.

## Issues Resolved

Using the versioned URL should now fix #628 

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
