### PR TITLE
Use standard dokken file and remove EOL Debian 9

### DIFF
--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -22,14 +22,16 @@ jobs:
     strategy:
       matrix:
         os:
+          - almalinux-8
           - amazonlinux-2
-          - debian-9
           - debian-10
           - debian-11
           - centos-7
-          - centos-8
+          - centos-stream-8
           - ubuntu-1804
           - ubuntu-2004
+          - ubuntu-2204
+          - rockylinux-8
         suite:
           - openjdk-11
           - openjdk-16

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,74 +1,113 @@
----
 driver:
   name: dokken
-  privileged: true  # because Docker and SystemD/Upstart
+  privileged: true
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
-transport:
-  name: dokken
-
-provisioner:
-  name: dokken
-
-verifier:
-  name: inspec
+transport: { name: dokken }
+provisioner: { name: dokken }
 
 platforms:
-  - name: amazonlinux-2
+  - name: almalinux-8
     driver:
-      image: dokken/amazonlinux-2
+      image: dokken/almalinux-8
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
+  - name: almalinux-9
     driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      # intermediate_instructions:
-      #   - RUN /usr/bin/apt-get update
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-10
+  - name: amazonlinux-2023
     driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-      # intermediate_instructions:
-      #   - RUN /usr/bin/apt-get update
-
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
-      # intermediate_instructions:
-      #   - RUN /usr/bin/apt-get update
+      image: dokken/amazonlinux-2023
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
+
+  - name: centos-stream-9
+    driver:
+      image: dokken/centos-stream-9
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: debian-9
+    driver:
+      image: dokken/debian-9
+      pid_one_command: /bin/systemd
+
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
+
+  - name: debian-12
+    driver:
+      image: dokken/debian-12
+      pid_one_command: /bin/systemd
 
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: opensuse-leap-15
+    driver:
+      image: dokken/opensuse-leap-15
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: oraclelinux-7
+    driver:
+      image: dokken/oraclelinux-7
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: oraclelinux-8
+    driver:
+      image: dokken/oraclelinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: oraclelinux-9
+    driver:
+      image: dokken/oraclelinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-9
+    driver:
+      image: dokken/rockylinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
-  - name: opensuse-leap-15
+  - name: ubuntu-22.04
     driver:
-      image: dokken/opensuse-leap-15
+      image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd
+
+  - name: ubuntu-23.04
+    driver:
+      image: dokken/ubuntu-23.04
       pid_one_command: /bin/systemd


### PR DESCRIPTION
# Description

Remove Debian 9 which is now EOL. As a result, no packages can be installed on the system breaking CI. 