### PR TITLE
fix: typo, 'opendjdk' should be 'openjdk'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- fix OpenJDK variant typo
+
 ## 12.0.0 - *2023-09-29*
 
 ## 11.2.2 - *2023-09-28*

--- a/resources/openjdk_source_install.rb
+++ b/resources/openjdk_source_install.rb
@@ -7,7 +7,7 @@ property :version, String,
           description: 'Java version to install'
 
 property :variant, String,
-          equal_to: %w(opendjdk semeru temurin),
+          equal_to: %w(openjdk semeru temurin),
           default: 'openjdk',
           description: 'Install flavour'
 


### PR DESCRIPTION
# Description

Fix typo in `openjdk_source_install`

## Issues Resolved

https://github.com/sous-chefs/java/issues/701

## Check List

- [x]  A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
