### PR TITLE
[GH-711] Fix openjdk_pkg_install to obey pkg_version property for all pkg_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
-Standardise files with files in sous-chefs/repo-management
+- Fix `openjdk_pkg_install` to obey `pkg_version` property for all `pkg_names`
 
 ## 11.2.2 - *2023-09-28*
 

--- a/resources/openjdk_pkg_install.rb
+++ b/resources/openjdk_pkg_install.rb
@@ -31,8 +31,15 @@ action :install do
     end
   end
 
+  pkg_version =
+    if new_resource.pkg_version && new_resource.pkg_names.is_a?(String)
+      version new_resource.pkg_version
+    elsif new_resource.pkg_version && new_resource.pkg_names.is_a?(Array)
+      Array.new(new_resource.pkg_names.size, new_resource.pkg_version)
+    end
+
   package new_resource.pkg_names do
-    version new_resource.pkg_version if new_resource.pkg_version
+    version pkg_version if pkg_version
   end
 
   node.default['java']['java_home'] = new_resource.java_home


### PR DESCRIPTION
# Description

Allows to have version locked openjdk installs from packages.

## Issues Resolved

https://github.com/sous-chefs/java/issues/711

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
