### PR TITLE
Update `java_certificate` to function on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- Update `install` and `remove` actions of `java_certificate` to function on Windows
+
 ## 12.1.1 - *2024-12-05*
 
 ## 12.1.0 - *2024-12-03*


### PR DESCRIPTION
# Description

Updates the `install` and `remove` actions of `java_certificate` to function on Windows

Adding Windows tests for just this is a bit complicated since the Java install resources don't currently support Windows.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
