### PR TITLE
new property `skip_alternatives` for coretto-, openjdk-,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the Java cookbook.
 
 ## Unreleased
 
+- add `skip_alternatives` to resources `corretto_install`, `openjdk_install`, `openjdk_pkg_install`, `openjdk_source_install` for cases when management of alternatives is not desired.
+- update package vs source selection for rhel 10 and derivatives, debian 12.
+- exclude failing binaries from list of alternatives for suse.
+
 ## 12.1.1 - *2024-12-05*
 
 ## 12.1.0 - *2024-12-03*

--- a/documentation/resources/corretto_install.md
+++ b/documentation/resources/corretto_install.md
@@ -22,10 +22,11 @@ Introduced: v8.0.0
 | java_home_mode        | Integer, String | `0755`                               | The permission for the Java home directory                                                                        |
 | java_home_owner       | String          | `root`                               | Owner of the Java Home                                                                                            |
 | java_home_group       | String          | `node['root_group']`                 | Group for the Java Home                                                                                           |
-| default               | Boolean         | `true`                               | Whether to set this as the defalut Java                                                                           |
+| default               | Boolean         | `true`                               | Whether to set this as the default Java                                                                           |
 | bin_cmds              | Array           | `default_corretto_bin_cmds(version)` | A list of bin_cmds based on the version and variant                                                               |
 | alternatives_priority | Integer         | `1`                                  | Alternatives priority to set for this Java                                                                        |
 | reset_alternatives    | Boolean         | `true`                               | Whether to reset alternatives before setting                                                                      |
+| skip_alternatives     | Boolean         | `false`             | Whether to skip management of alternatives (makes `default`, `bin_cmds`, `alternatives_priority`, `reset_alternatives` irrelevant) |
 
 ## Examples
 

--- a/documentation/resources/openjdk_install.md
+++ b/documentation/resources/openjdk_install.md
@@ -21,10 +21,11 @@ Introduced: v8.0.0
 | java_home_mode        | Integer, String |         | The permission for the Java home directory          |                    |
 | java_home_owner       | String          |         | Owner of the Java Home                              |                    |
 | java_home_group       | String          |         | Group for the Java Home                             |                    |
-| default               | Boolean         |         | Whether to set this as the defalut Java             |                    |
+| default               | Boolean         |         | Whether to set this as the default Java             |                    |
 | bin_cmds              | Array           |         | A list of bin_cmds based on the version and variant |                    |
 | alternatives_priority | Integer         |         | Alternatives priority to set for this Java          |                    |
 | reset_alternatives    | Boolean         |         | Whether to reset alternatives before setting        |                    |
+| skip_alternatives     | Boolean         | `false` | Whether to skip management of alternatives (makes `default`, `bin_cmds`, `alternatives_priority`, `reset_alternatives` irrelevant) |
 | pkg_names             | Array           |         | List of packages to install                         |                    |
 | pkg_version           | String          |         | Package version to install                          |                    |
 | install_type          | String          |         | Installation type                                   | `package` `source` |

--- a/documentation/resources/openjdk_pkg_install.md
+++ b/documentation/resources/openjdk_pkg_install.md
@@ -18,10 +18,11 @@ Introduced: v8.1.0
 | pkg_names             | Array   | `default_openjdk_pkg_names(version)` | List of packages to install                         |
 | pkg_version           | String  | `nil`                                | Package version to install                          |
 | java_home             | String  | Based on the version                 | Set to override the java_home                       |
-| default               | Boolean | `true`                               | Whether to set this as the defalut Java             |
+| default               | Boolean | `true`                               | Whether to set this as the default Java             |
 | bin_cmds              | Array   | `default_openjdk_bin_cmds(version)`  | A list of bin_cmds based on the version and variant |
 | alternatives_priority | Integer | `1062`                               | Alternatives priority to set for this Java          |
 | reset_alternatives    | Boolean | `true`                               | Whether to reset alternatives before setting        |
+| skip_alternatives     | Boolean | `false`                              | Whether to skip management of alternatives (makes `default`, `bin_cmds`, `alternatives_priority`, `reset_alternatives` irrelevant) |
 
 ## Examples
 

--- a/documentation/resources/openjdk_source_install.md
+++ b/documentation/resources/openjdk_source_install.md
@@ -21,10 +21,11 @@ Introduced: v8.0.0
 | java_home_mode        | Integer, String | `0755`                              | The permission for the Java home directory          |
 | java_home_owner       | String          | `root`                              | Owner of the Java Home                              |
 | java_home_group       | String          | `node['root_group']`                | Group for the Java Home                             |
-| default               | Boolean         | `true`                              | Whether to set this as the defalut Java             |
+| default               | Boolean         | `true`                              | Whether to set this as the default Java             |
 | bin_cmds              | Array           | `default_openjdk_bin_cmds(version)` | A list of bin_cmds based on the version and variant |
 | alternatives_priority | Integer         | `1`                                 | Alternatives priority to set for this Java          |
 | reset_alternatives    | Boolean         | `true`                              | Whether to reset alternatives before setting        |
+| skip_alternatives     | Boolean         | `false`                             | Whether to skip management of alternatives (makes `default`, `bin_cmds`, `alternatives_priority`, `reset_alternatives` irrelevant) |
 
 ## Examples
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -41,16 +41,25 @@ platforms:
     driver:
       image: dokken/debian-11
       pid_one_command: /bin/systemd
+    lifecycle:
+      pre_converge:
+        remote: apt-get update
 
   - name: debian-12
     driver:
       image: dokken/debian-12
       pid_one_command: /bin/systemd
+    lifecycle:
+      pre_converge:
+        remote: apt-get update
 
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
+    lifecycle:
+      pre_converge:
+        remote: dnf -y install python3-dnf
 
   - name: opensuse-leap-15
     driver:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -6,6 +6,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'warn' %>
 
 verifier:
   name: inspec
@@ -47,46 +48,97 @@ suites:
       inspec_tests: [test/integration/openjdk]
       inputs: { java_version: "17" }
 
-  # Temurin/Semeru
-  - name: temurin-8-hotspot
+  # OpenJDK skip alternatives
+  - name: openjdk-no-alt-11
     run_list:
-      - recipe[test::openjdk]
-    attributes:
-      version: 8
-      variant: hotspot
+      - recipe[test::openjdk_no_alt]
+    attributes: { version: "11" }
     verifier:
-      inspec_tests: [test/integration/openjdk]
-      inputs: { java_version: "8" }
-
-  - name: temurin-11-hotspot
-    run_list:
-      - recipe[test::openjdk]
-    attributes:
-      version: 11
-      variant: hotspot
-    verifier:
-      inspec_tests: [test/integration/openjdk]
+      inspec_tests: [test/integration/openjdk_no_alt]
       inputs: { java_version: "11" }
 
-  - name: semeru-11-openj9
+  - name: openjdk-no-alt-16
     run_list:
-      - recipe[test::openjdk]
-    attributes:
-      version: 11
-      variant: openj9
+      - recipe[test::openjdk_no_alt]
+    attributes: { version: "16" }
     verifier:
-      inspec_tests: [test/integration/openjdk]
-      inputs: { java_version: "11" }
+      inspec_tests: [test/integration/openjdk_no_alt]
+      inputs: { java_version: "16" }
 
-  - name: semeru-17-openj9
+  - name: openjdk-no-alt-17
     run_list:
-      - recipe[test::openjdk]
-    attributes:
-      version: 17
-      variant: openj9
+      - recipe[test::openjdk_no_alt]
+    attributes: { version: "17" }
     verifier:
-      inspec_tests: [test/integration/openjdk]
+      inspec_tests: [test/integration/openjdk_no_alt]
       inputs: { java_version: "17" }
+
+  # OpenJDK pkg skip alternatives
+  - name: openjdk-pkg-no-alt-11
+    run_list:
+      - recipe[test::openjdk_pkg_no_alt]
+    attributes: { version: "11" }
+    verifier:
+      inspec_tests: [test/integration/openjdk_no_alt]
+      inputs: { java_version: "11" }
+    excludes:
+      - almalinux-10
+      - centos-stream-10
+      - amazonlinux-2023
+      - debian-12
+
+  - name: openjdk-pkg-no-alt-21
+    run_list:
+      - recipe[test::openjdk_pkg_no_alt]
+    attributes: { version: "21" }
+    verifier:
+      inspec_tests: [test/integration/openjdk_no_alt]
+      inputs: { java_version: "21" }
+    includes:
+      - almalinux-10
+      - centos-stream-10
+
+  # Temurin/Semeru
+  # disabled until #709
+  # - name: temurin-8-hotspot
+  #   run_list:
+  #     - recipe[test::openjdk]
+  #   attributes:
+  #     version: 8
+  #     variant: hotspot
+  #   verifier:
+  #     inspec_tests: [test/integration/openjdk]
+  #     inputs: { java_version: "8" }
+
+  # - name: temurin-11-hotspot
+  #   run_list:
+  #     - recipe[test::openjdk]
+  #   attributes:
+  #     version: 11
+  #     variant: hotspot
+  #   verifier:
+  #     inspec_tests: [test/integration/openjdk]
+  #     inputs: { java_version: "11" }
+
+  # - name: semeru-11-openj9
+  #   run_list:
+  #     - recipe[test::openjdk]
+  #   attributes:
+  #     version: 11
+  #     variant: openj9
+  #   verifier:
+  #     inspec_tests: [test/integration/openjdk]
+  #     inputs: { java_version: "11" }
+
+  # - name: semeru-17-openj9
+  #   run_list:
+  #     - recipe[test::openjdk]
+  #   attributes:
+  #     version: 17
+  #     variant: openj9
+  #   verifier:
+  #     inspec_tests: [test/integration/openjdk]
+  #     inputs: { java_version: "17" }
 
   # Corretto
   - name: corretto-8
@@ -116,4 +168,34 @@ suites:
     attributes: { version: "18" }
     verifier:
       inspec_tests: [test/integration/corretto]
+      inputs: { java_version: "18" }
+
+  # Corretto skip alternatives
+  - name: corretto-no-alt-8
+    run_list:
+      - recipe[test::corretto_no_alt]
+    attributes: { version: "8" }
+    verifier:
+      inspec_tests: [test/integration/corretto_no_alt]
+      inputs: { java_version: "8" }
+  - name: corretto-no-alt-11
+    run_list:
+      - recipe[test::corretto_no_alt]
+    attributes: { version: "11" }
+    verifier:
+      inspec_tests: [test/integration/corretto_no_alt]
+      inputs: { java_version: "11" }
+  - name: corretto-no-alt-17
+    run_list:
+      - recipe[test::corretto_no_alt]
+    attributes: { version: "17" }
+    verifier:
+      inspec_tests: [test/integration/corretto_no_alt]
+      inputs: { java_version: "17" }
+  - name: corretto-no-alt-18
+    run_list:
+      - recipe[test::corretto_no_alt]
+    attributes: { version: "18" }
+    verifier:
+      inspec_tests: [test/integration/corretto_no_alt]
       inputs: { java_version: "18" }

--- a/libraries/openjdk_helpers.rb
+++ b/libraries/openjdk_helpers.rb
@@ -17,10 +17,16 @@ module Java
         when 'amazon'
           'source'
         when 'rhel'
-          supported = lts.delete('11')
-          supported.include?(version) ? 'package' : 'source'
+          case node['platform_version']
+          when '8', '9'
+            %w(1.8.0 11 17 21).include?(version) ? 'package' : 'source'
+          else
+            %w(21).include?(version) ? 'package' : 'source'
+          end
         when 'debian'
           case node['platform_version']
+          when '12'
+            '17'.eql?(version) ? 'package' : 'source'
           when '10', '18.04'
             supported = lts - ['17']
             supported.include?(version) ? 'package' : 'source'
@@ -139,9 +145,17 @@ module Java
         when '10'
           %w(appletviewer idlj jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool orbd pack200 rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
         when '11'
-          %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
+          if platform_family?('suse')
+            %w(jaotc java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
+          else
+            %w(jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200)
+          end
         when '12', '13', '14', '15', '16', '17', '19', '20', '21', '22', 'latest'
-          %w(jaotc jarsigner javac javap jconsole jdeprscan jfr jimage jjs jmap jps jshell jstat keytool rmic rmiregistry unpack200 jar java javadoc jcmd jdb jdeps jhsdb jinfo jlink jmod jrunscript jstack jstatd pack200 rmid serialver)
+          if platform_family?('suse')
+            %w(jaotc javac javap jconsole jdeprscan jfr jimage jjs jmap jps jshell jstat rmic unpack200 java javadoc jcmd jdb jdeps jhsdb jinfo jlink jmod jrunscript jstack jstatd pack200 rmid serialver)
+          else
+            %w(jaotc jarsigner javac javap jconsole jdeprscan jfr jimage jjs jmap jps jshell jstat keytool rmic rmiregistry unpack200 jar java javadoc jcmd jdb jdeps jhsdb jinfo jlink jmod jrunscript jstack jstatd pack200 rmid serialver)
+          end
         else
           Chef::Log.fatal('Version specified does not have a default set of bin_cmds')
         end

--- a/resources/corretto_install.rb
+++ b/resources/corretto_install.rb
@@ -73,7 +73,7 @@ action :install do
     default new_resource.default
     reset_alternatives new_resource.reset_alternatives
     action :set
-  end
+  end unless new_resource.skip_alternatives
 end
 
 action :remove do
@@ -84,7 +84,7 @@ action :remove do
     bin_cmds new_resource.bin_cmds
     only_if { ::File.exist?(extract_dir) }
     action :unset
-  end
+  end unless new_resource.skip_alternatives
 
   directory "Removing #{extract_dir}" do
     path extract_dir

--- a/resources/openjdk_install.rb
+++ b/resources/openjdk_install.rb
@@ -46,6 +46,7 @@ action :install do
       bin_cmds new_resource.bin_cmds
       alternatives_priority new_resource.alternatives_priority
       reset_alternatives new_resource.reset_alternatives
+      skip_alternatives new_resource.skip_alternatives
     end
   elsif new_resource.install_type == 'source'
     openjdk_source_install new_resource.version do
@@ -58,6 +59,7 @@ action :install do
       bin_cmds new_resource.bin_cmds
       alternatives_priority new_resource.alternatives_priority
       reset_alternatives new_resource.reset_alternatives
+      skip_alternatives new_resource.skip_alternatives
     end
   else
     ChefLog.fatal('Invalid install method specified')
@@ -74,6 +76,7 @@ action :remove do
       bin_cmds new_resource.bin_cmds
       alternatives_priority new_resource.alternatives_priority
       reset_alternatives new_resource.reset_alternatives
+      skip_alternatives new_resource.skip_alternatives
       action :remove
     end
   elsif new_resource.install_type == 'source'
@@ -87,6 +90,7 @@ action :remove do
       bin_cmds new_resource.bin_cmds
       alternatives_priority new_resource.alternatives_priority
       reset_alternatives new_resource.reset_alternatives
+      skip_alternatives new_resource.skip_alternatives
       action :remove
     end
   else

--- a/resources/openjdk_pkg_install.rb
+++ b/resources/openjdk_pkg_install.rb
@@ -51,7 +51,7 @@ action :install do
     default new_resource.default
     reset_alternatives new_resource.reset_alternatives
     action :set
-  end
+  end unless new_resource.skip_alternatives
 end
 
 action :remove do
@@ -60,7 +60,7 @@ action :remove do
     bin_cmds new_resource.bin_cmds
     only_if { ::File.exist?(new_resource.java_home) }
     action :unset
-  end
+  end unless new_resource.skip_alternatives
 
   package new_resource.pkg_names do
     action :remove

--- a/resources/openjdk_source_install.rb
+++ b/resources/openjdk_source_install.rb
@@ -65,7 +65,7 @@ action :install do
     default new_resource.default
     reset_alternatives new_resource.reset_alternatives
     action :set
-  end
+  end unless new_resource.skip_alternatives
 
   append_if_no_line 'Java Home' do
     path '/etc/profile.d/java.sh'
@@ -81,7 +81,7 @@ action :remove do
     bin_cmds new_resource.bin_cmds
     only_if { ::File.exist?(extract_dir) }
     action :unset
-  end
+  end unless new_resource.skip_alternatives
 
   directory "Removing #{extract_dir}" do
     path extract_dir

--- a/resources/partial/_linux.rb
+++ b/resources/partial/_linux.rb
@@ -6,6 +6,10 @@ property :reset_alternatives, [true, false],
         default: true,
         description: 'Whether to reset alternatives before setting'
 
+property :skip_alternatives, [true, false],
+        default: false,
+        description: 'Whether to skip management of alternatives or not'
+
 property :default, [true, false],
         default: true,
         description: ' Whether to set this as the default Java'

--- a/test/integration/openjdk/controls/verify_openjdk.rb
+++ b/test/integration/openjdk/controls/verify_openjdk.rb
@@ -10,5 +10,9 @@ control 'Java is installed & linked correctly' do
 
   describe command('update-alternatives --display jar') do
     its('stdout') { should match %r{/usr/lib/jvm/java} }
-  end
+  end unless os.suse?
+
+  describe command('update-alternatives --display java') do
+    its('stdout') { should match %r{/usr/lib(64)?/jvm/java} }
+  end if os.suse?
 end


### PR DESCRIPTION
openjdk_source-, openjdk_pkg- install resources

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
